### PR TITLE
Segregate trace queues and periodic sampling states

### DIFF
--- a/assertsprocessor/factory.go
+++ b/assertsprocessor/factory.go
@@ -2,14 +2,15 @@ package assertsprocessor
 
 import (
 	"context"
+	"regexp"
+	"sync"
+	"time"
+
 	"github.com/tilinna/clock"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/processor"
 	"go.uber.org/zap"
-	"regexp"
-	"sync"
-	"time"
 )
 
 const (
@@ -35,7 +36,7 @@ func createDefaultConfig() component.Config {
 		},
 		Env:                            "dev",
 		Site:                           "us-west-2",
-		DefaultLatencyThreshold:        0.5,
+		DefaultLatencyThreshold:        3,
 		LimitPerService:                100,
 		LimitPerRequestPerService:      5,
 		NormalSamplingFrequencyMinutes: 5,

--- a/assertsprocessor/factory_test.go
+++ b/assertsprocessor/factory_test.go
@@ -2,10 +2,11 @@ package assertsprocessor
 
 import (
 	"context"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"testing"
 )
 
 type dummyConsumer struct {
@@ -33,7 +34,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, "dev", pConfig.Env)
 	assert.Equal(t, "us-west-2", pConfig.Site)
 	assert.Equal(t, 100, pConfig.LimitPerService)
-	assert.Equal(t, 0.5, pConfig.DefaultLatencyThreshold)
+	assert.Equal(t, float64(3), pConfig.DefaultLatencyThreshold)
 }
 
 //func TestCreateProcessor(t *testing.T) {

--- a/assertsprocessor/sampler.go
+++ b/assertsprocessor/sampler.go
@@ -65,10 +65,10 @@ func (s *sampler) sampleTrace(ctx context.Context,
 		ctx:     &ctx,
 		latency: summary.latency,
 	}
-	serviceKey := summary.requestKey.entityKey.AsString()
+	entityKey := summary.requestKey.entityKey.AsString()
 	if summary.hasError || summary.isSlow {
 		// Get the trace queue for the entity and request
-		perService, _ := s.topTracesByService.LoadOrStore(serviceKey, NewServiceQueues(s.config))
+		perService, _ := s.topTracesByService.LoadOrStore(entityKey, NewServiceQueues(s.config))
 		requestState := perService.(*serviceQueues).getRequestState(summary.requestKey.request)
 
 		// If there are too many requests, we may not get a queue due to constraints
@@ -87,10 +87,10 @@ func (s *sampler) sampleTrace(ctx context.Context,
 		}
 	} else if len(spanSet.rootSpans) > 0 && summary.requestKey.AsString() != "" {
 		// Capture healthy samples based on configured sampling rate
-		entry, _ := s.topTracesByService.LoadOrStore(serviceKey, NewServiceQueues(s.config))
+		entry, _ := s.topTracesByService.LoadOrStore(entityKey, NewServiceQueues(s.config))
 		perService := entry.(*serviceQueues)
 		requestState := perService.getRequestState(summary.requestKey.request)
-		samplingState, _ := perService.periodicSamplingStates.LoadOrStore(serviceKey, &periodicSamplingState{
+		samplingState, _ := perService.periodicSamplingStates.LoadOrStore(entityKey, &periodicSamplingState{
 			lastSampleTime: 0,
 			rwMutex:        &sync.RWMutex{},
 		})
@@ -168,7 +168,7 @@ func (s *sampler) startTraceFlusher() {
 							s.logger.Debug("Flushing Error Traces for",
 								zap.String("Service", entityKey),
 								zap.String("Request", requestKey),
-								zap.Int("Count", _sampler.errorQueue.priorityQueue.Len()))
+								zap.Int("Count", len(_sampler.errorQueue.priorityQueue)))
 							for _, item := range _sampler.errorQueue.priorityQueue {
 								_ = (*s).nextConsumer.ConsumeTraces(*item.ctx, *item.trace)
 							}
@@ -179,7 +179,7 @@ func (s *sampler) startTraceFlusher() {
 							s.logger.Debug("Flushing Slow Traces for",
 								zap.String("Service", entityKey),
 								zap.String("Request", requestKey),
-								zap.Int("Count", _sampler.slowQueue.priorityQueue.Len()))
+								zap.Int("Count", len(_sampler.slowQueue.priorityQueue)))
 							for _, item := range _sampler.slowQueue.priorityQueue {
 								_ = (*s).nextConsumer.ConsumeTraces(*item.ctx, *item.trace)
 							}

--- a/assertsprocessor/service_queue_test.go
+++ b/assertsprocessor/service_queue_test.go
@@ -1,8 +1,9 @@
 package assertsprocessor
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewServiceQueues(t *testing.T) {
@@ -48,9 +49,6 @@ func TestNewServiceQueues_Limit_One(t *testing.T) {
 	assert.NotNil(t, queue.slowQueue.mutex)
 	assert.Equal(t, 5, queue.slowQueue.maxSize)
 
-	assert.NotNil(t, queue.samplingState)
-	assert.True(t, queue.samplingState.sample(1))
-
 	queue = sq.getRequestState("/request2")
 	assert.Equal(t, 1, sq.requestCount)
 	assert.Nil(t, queue)
@@ -77,9 +75,6 @@ func TestNewServiceQueues_Limit_Two(t *testing.T) {
 	assert.NotNil(t, queue.slowQueue.priorityQueue)
 	assert.NotNil(t, queue.slowQueue.mutex)
 	assert.Equal(t, 5, queue.slowQueue.maxSize)
-
-	assert.NotNil(t, queue.samplingState)
-	assert.True(t, queue.samplingState.sample(1))
 
 	queue = sq.getRequestState("/request2")
 	assert.NotNil(t, queue)


### PR DESCRIPTION
- The queues are reset after each minute. Segregating will avoid the periodic
  sampling states (which keeps track of the last time when a normal trace was
  sampled) from getting wiped out each minute