### PR TITLE
Create metrics for root span, all entry and exit spans

### DIFF
--- a/assertsprocessor/config.go
+++ b/assertsprocessor/config.go
@@ -14,7 +14,6 @@ type Config struct {
 	AssertsServer                  *map[string]string `mapstructure:"asserts_server"`
 	Env                            string             `mapstructure:"asserts_env"`
 	Site                           string             `mapstructure:"asserts_site"`
-	AttributeExps                  *map[string]string `mapstructure:"span_attribute_match_regex"`
 	RequestContextExps             *[]*MatcherDto     `mapstructure:"request_context_regex"`
 	CaptureAttributesInMetric      []string           `mapstructure:"attributes_as_metric_labels"`
 	DefaultLatencyThreshold        float64            `mapstructure:"sampling_latency_threshold_seconds"`
@@ -28,13 +27,6 @@ type Config struct {
 // Validate implements the component.ConfigValidator interface.
 // Checks for any invalid regexp
 func (config *Config) Validate() error {
-	for _, exp := range *config.AttributeExps {
-		_, err := regexp.Compile(exp)
-		if err != nil {
-			return err
-		}
-	}
-
 	for _, attrRegex := range *config.RequestContextExps {
 		_, err := regexp.Compile(attrRegex.Regex)
 		if err != nil {

--- a/assertsprocessor/config_test.go
+++ b/assertsprocessor/config_test.go
@@ -8,9 +8,6 @@ import (
 
 func TestValidateNoError(t *testing.T) {
 	dto := Config{
-		AttributeExps: &map[string]string{
-			"attribute": ".+",
-		},
 		RequestContextExps: &[]*MatcherDto{{
 			AttrName: "attribute",
 			Regex:    ".+",
@@ -20,25 +17,8 @@ func TestValidateNoError(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestValidateAttributeExpError(t *testing.T) {
-	dto := Config{
-		AttributeExps: &map[string]string{
-			"attribute": "+",
-		},
-		RequestContextExps: &[]*MatcherDto{{
-			AttrName: "attribute",
-			Regex:    ".+",
-		}},
-	}
-	err := dto.Validate()
-	assert.NotNil(t, err)
-}
-
 func TestValidateRequestExpError(t *testing.T) {
 	dto := Config{
-		AttributeExps: &map[string]string{
-			"attribute": ".+",
-		},
 		RequestContextExps: &[]*MatcherDto{{
 			AttrName: "attribute",
 			Regex:    "+",
@@ -50,9 +30,6 @@ func TestValidateRequestExpError(t *testing.T) {
 
 func TestValidateLimits(t *testing.T) {
 	dto := Config{
-		AttributeExps: &map[string]string{
-			"attribute": ".+",
-		},
 		RequestContextExps: &[]*MatcherDto{{
 			AttrName: "attribute",
 			Regex:    ".+",

--- a/assertsprocessor/metrics_test.go
+++ b/assertsprocessor/metrics_test.go
@@ -6,55 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
-	"regexp"
 	"testing"
 	"time"
 )
 
-func TestShouldCaptureMetrics(t *testing.T) {
-	logger, _ := zap.NewProduction()
-	p := metricHelper{
-		logger: logger,
-		config: &Config{
-			AttributeExps: &map[string]string{
-				"rpc.system":  "aws-api",
-				"rpc.service": "(Sqs)|(DynamoDb)",
-			},
-		},
-		attributeValueRegExps: &map[string]*regexp.Regexp{},
-	}
-
-	err := p.compileSpanFilterRegexps()
-	if err != nil {
-		return
-	}
-
-	testSpan := ptrace.NewSpan()
-	testSpan.Attributes().PutStr("rpc.system", "aws-api")
-	testSpan.Attributes().PutStr("rpc.service", "DynamoDb")
-	assert.True(t, p.shouldCaptureMetrics(&testSpan))
-
-	testSpan.Attributes().PutStr("rpc.service", "Sqs")
-	assert.True(t, p.shouldCaptureMetrics(&testSpan))
-
-	testSpan.Attributes().PutStr("rpc.system", "kafka")
-	assert.False(t, p.shouldCaptureMetrics(&testSpan))
-
-	testSpan.Attributes().PutStr("rpc.system", "aws-api")
-	testSpan.Attributes().PutStr("rpc.service", "Ecs")
-	assert.False(t, p.shouldCaptureMetrics(&testSpan))
-}
-
 func TestBuildLabels(t *testing.T) {
-	systemPattern, _ := regexp.Compile("aws-api")
-	servicePattern, _ := regexp.Compile("(Sqs)|(DynamoDb)")
 	logger, _ := zap.NewProduction()
 	p := metricHelper{
 		logger: logger,
-		attributeValueRegExps: &map[string]*regexp.Regexp{
-			"rpc.system":  systemPattern,
-			"rpc.service": servicePattern,
-		},
 		config: &Config{
 			Env:  "dev",
 			Site: "us-west-2",
@@ -85,15 +44,9 @@ func TestBuildLabels(t *testing.T) {
 }
 
 func TestCaptureMetrics(t *testing.T) {
-	systemPattern, _ := regexp.Compile("aws-api")
-	servicePattern, _ := regexp.Compile("(Sqs)|(DynamoDb)")
 	logger, _ := zap.NewProduction()
 	p := metricHelper{
 		logger: logger,
-		attributeValueRegExps: &map[string]*regexp.Regexp{
-			"rpc.system":  systemPattern,
-			"rpc.service": servicePattern,
-		},
 		config: &Config{
 			Env:  "dev",
 			Site: "us-west-2",
@@ -129,15 +82,9 @@ func TestCaptureMetrics(t *testing.T) {
 }
 
 func TestStartExporter(t *testing.T) {
-	systemPattern, _ := regexp.Compile("aws-api")
-	servicePattern, _ := regexp.Compile("(Sqs)|(DynamoDb)")
 	logger, _ := zap.NewProduction()
 	p := metricHelper{
 		logger: logger,
-		attributeValueRegExps: &map[string]*regexp.Regexp{
-			"rpc.system":  systemPattern,
-			"rpc.service": servicePattern,
-		},
 		config: &Config{
 			Env:                    "dev",
 			Site:                   "us-west-2",

--- a/assertsprocessor/processor.go
+++ b/assertsprocessor/processor.go
@@ -27,9 +27,6 @@ func (p *assertsProcessorImpl) Capabilities() consumer.Capabilities {
 // Start implements the component.Component interface.
 func (p *assertsProcessorImpl) Start(ctx context.Context, host component.Host) error {
 	p.logger.Info("consumer.Start callback")
-	if err := p.metricBuilder.compileSpanFilterRegexps(); err != nil {
-		return err
-	}
 	p.sampler.startProcessing()
 	return nil
 }
@@ -54,6 +51,10 @@ func (p *assertsProcessorImpl) processSpans(ctx context.Context, traces *resourc
 	for _, aTrace := range *traces.traceById {
 		if aTrace.rootSpan != nil {
 			p.metricBuilder.captureMetrics(traces.namespace, traces.service, aTrace.rootSpan)
+		}
+
+		for _, entrySpan := range aTrace.entrySpans {
+			p.metricBuilder.captureMetrics(traces.namespace, traces.service, entrySpan)
 		}
 
 		for _, exitSpan := range aTrace.exitSpans {

--- a/assertsprocessor/sampler_test.go
+++ b/assertsprocessor/sampler_test.go
@@ -69,7 +69,7 @@ func TestLatencyIsHighFalse(t *testing.T) {
 //		config:          &config,
 //		thresholdHelper: &th,
 //		topTracesByService:    &cache,
-//		requestRegexps: &map[string]regexp.Regexp{
+//		spanAttrMatchers: &map[string]regexp.Regexp{
 //			"http.url": *compile,
 //		},
 //		healthySamplingState: &sync.Map{},
@@ -122,19 +122,20 @@ func TestSampleTraceWithHighLatency(t *testing.T) {
 	cache := sync.Map{}
 	compile, err := regexp.Compile("https?://.+?(/.+)")
 	assert.Nil(t, err)
-	var s = sampler{
+	s := sampler{
 		logger:             logger,
 		config:             &config,
 		thresholdHelper:    &th,
 		topTracesByService: &cache,
-		requestRegexps: &[]*Matcher{
-			{
-				attrName: "http.url",
-				regex:    compile,
+		spanMatcher: &spanMatcher{
+			spanAttrMatchers: []*spanAttrMatcher{
+				{
+					attrName: "http.url",
+					regex:    compile,
+				},
 			},
 		},
 	}
-
 	ctx := context.Background()
 	testTrace := ptrace.NewTraces()
 	resourceSpans := testTrace.ResourceSpans().AppendEmpty()
@@ -200,10 +201,12 @@ func TestSampleNormalTrace(t *testing.T) {
 		config:             &config,
 		thresholdHelper:    &th,
 		topTracesByService: &cache,
-		requestRegexps: &[]*Matcher{
-			{
-				attrName: "http.url",
-				regex:    compile,
+		spanMatcher: &spanMatcher{
+			spanAttrMatchers: []*spanAttrMatcher{
+				{
+					attrName: "http.url",
+					regex:    compile,
+				},
 			},
 		},
 	}
@@ -276,10 +279,12 @@ func TestFlushTraces(t *testing.T) {
 		config:             &config,
 		thresholdHelper:    &th,
 		topTracesByService: &cache,
-		requestRegexps: &[]*Matcher{
-			{
-				attrName: "http.url",
-				regex:    compile,
+		spanMatcher: &spanMatcher{
+			spanAttrMatchers: []*spanAttrMatcher{
+				{
+					attrName: "http.url",
+					regex:    compile,
+				},
 			},
 		},
 		traceFlushTicker: clock.FromContext(ctx).NewTicker(time.Second),

--- a/assertsprocessor/span_matcher.go
+++ b/assertsprocessor/span_matcher.go
@@ -1,0 +1,48 @@
+package assertsprocessor
+
+import (
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+	"regexp"
+)
+
+type spanAttrMatcher struct {
+	attrName string
+	regex    *regexp.Regexp
+}
+
+type spanMatcher struct {
+	spanAttrMatchers []*spanAttrMatcher
+}
+
+func (sm *spanMatcher) compileRequestContextRegexps(logger *zap.Logger, config *Config) error {
+	logger.Info("compiling request context regexps")
+	sm.spanAttrMatchers = make([]*spanAttrMatcher, 0)
+	if config.RequestContextExps != nil {
+		for _, matcher := range *config.RequestContextExps {
+			compile, err := regexp.Compile(matcher.Regex)
+			if err != nil {
+				return err
+			}
+			sm.spanAttrMatchers = append(sm.spanAttrMatchers, &spanAttrMatcher{
+				attrName: matcher.AttrName,
+				regex:    compile,
+			})
+		}
+	}
+	logger.Debug("compiled request context regexps successfully")
+	return nil
+}
+
+func (sm *spanMatcher) getRequest(span *ptrace.Span) string {
+	for _, matcher := range sm.spanAttrMatchers {
+		value, found := span.Attributes().Get(matcher.attrName)
+		if found {
+			subMatch := matcher.regex.FindStringSubmatch(value.AsString())
+			if len(subMatch) >= 1 {
+				return subMatch[1]
+			}
+		}
+	}
+	return span.Name()
+}

--- a/assertsprocessor/span_matcher.go
+++ b/assertsprocessor/span_matcher.go
@@ -16,7 +16,7 @@ type spanMatcher struct {
 }
 
 func (sm *spanMatcher) compileRequestContextRegexps(logger *zap.Logger, config *Config) error {
-	logger.Info("compiling request context regexps")
+	logger.Info("Compiling request context regexps")
 	sm.spanAttrMatchers = make([]*spanAttrMatcher, 0)
 	if config.RequestContextExps != nil {
 		for _, matcher := range *config.RequestContextExps {
@@ -30,7 +30,7 @@ func (sm *spanMatcher) compileRequestContextRegexps(logger *zap.Logger, config *
 			})
 		}
 	}
-	logger.Debug("compiled request context regexps successfully")
+	logger.Debug("Compiled request context regexps successfully")
 	return nil
 }
 

--- a/assertsprocessor/span_matcher_test.go
+++ b/assertsprocessor/span_matcher_test.go
@@ -1,0 +1,94 @@
+package assertsprocessor
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+	"regexp"
+	"testing"
+)
+
+func TestCompileRequestContextRegexpsSuccess(t *testing.T) {
+	logger, _ := zap.NewProduction()
+	matcher := spanMatcher{}
+	err := matcher.compileRequestContextRegexps(logger, &Config{
+		RequestContextExps: &[]*MatcherDto{
+			{
+				AttrName: "attribute1",
+				Regex:    "Foo",
+			},
+			{
+				AttrName: "attribute2",
+				Regex:    "Bar.+",
+			},
+		},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, matcher.spanAttrMatchers)
+	assert.Equal(t, 2, len(matcher.spanAttrMatchers))
+
+	regExp := matcher.spanAttrMatchers[0].regex
+	assert.NotNil(t, regExp)
+	assert.Equal(t, "attribute1", matcher.spanAttrMatchers[0].attrName)
+	assert.True(t, regExp.MatchString("Foo"))
+
+	regExp = matcher.spanAttrMatchers[1].regex
+	assert.NotNil(t, regExp)
+	assert.Equal(t, "attribute2", matcher.spanAttrMatchers[1].attrName)
+	assert.True(t, regExp.MatchString("Bart"))
+}
+
+func TestCompileRequestContextRegexpsFailure(t *testing.T) {
+	logger, _ := zap.NewProduction()
+	matcher := spanMatcher{}
+	err := matcher.compileRequestContextRegexps(logger, &Config{
+		RequestContextExps: &[]*MatcherDto{
+			{
+				AttrName: "attribute1",
+				Regex:    "+",
+			},
+			{
+				AttrName: "attribute2",
+				Regex:    "Bar.+",
+			},
+		},
+	})
+	assert.NotNil(t, err)
+}
+
+func TestGetExpMatch(t *testing.T) {
+	testSpan := ptrace.NewSpan()
+	testSpan.Attributes().PutStr("http.url", "https://sqs.us-west-2.amazonaws.com/342994379019/NodeJSPerf-WithLayer")
+
+	compile, _ := regexp.Compile("https?://.+?(/.+?/.+)")
+	matcher := spanMatcher{
+		spanAttrMatchers: []*spanAttrMatcher{
+			{
+				attrName: "http.url",
+				regex:    compile,
+			},
+		},
+	}
+
+	value := matcher.getRequest(&testSpan)
+	assert.Equal(t, "/342994379019/NodeJSPerf-WithLayer", value)
+}
+
+func TestGetExpNoMatch(t *testing.T) {
+	testSpan := ptrace.NewSpan()
+	testSpan.SetName("BackgroundJob")
+	testSpan.Attributes().PutStr("http.url", "https://sqs.us-west-2.amazonaws.com/342994379019/NodeJSPerf-WithLayer")
+
+	compile, _ := regexp.Compile("https?://foo.+?(/.+?/.+)")
+	matcher := spanMatcher{
+		spanAttrMatchers: []*spanAttrMatcher{
+			{
+				attrName: "http.url",
+				regex:    compile,
+			},
+		},
+	}
+
+	value := matcher.getRequest(&testSpan)
+	assert.Equal(t, "BackgroundJob", value)
+}


### PR DESCRIPTION
- removed the span attribute match regex which was used earlier to select the spans for capturing metrics
- refactored the request context regexes into own type