### PR TITLE
Include googlecloudexporter

### DIFF
--- a/sample-builder-config.yaml
+++ b/sample-builder-config.yaml
@@ -16,12 +16,14 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.72.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.72.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.72.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.72.0
 extensions:
   - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.72.0
   - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.72.0
 processors:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.72.0
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.72.0
   - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.72.0
-  - gomod: github.com/asserts/asserts-otel-processor/assertsprocessor v0.0.54
+  - gomod: github.com/asserts/asserts-otel-processor/assertsprocessor v0.0.72
 connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.72.0


### PR DESCRIPTION
[ch15313]

Include [googlecloudexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter) exporter component in the asserts otel collector. This is needed to export traces to Google Cloud