### PR TITLE
Capture sampled trace count metrics

### DIFF
--- a/assertsprocessor/factory.go
+++ b/assertsprocessor/factory.go
@@ -82,6 +82,7 @@ func newProcessor(logger *zap.Logger, ctx context.Context, config component.Conf
 		nextConsumer:       nextConsumer,
 		spanMatcher:        spanMatcher,
 		stop:               make(chan bool),
+		metricHelper:       metricsHelper,
 	}
 
 	p := &assertsProcessorImpl{

--- a/assertsprocessor/factory_test.go
+++ b/assertsprocessor/factory_test.go
@@ -65,6 +65,7 @@ func TestCreateProcessor(t *testing.T) {
 	assert.NotNil(t, _assertsProcessor.metricBuilder.spanMatcher)
 	assert.NotNil(t, _assertsProcessor.metricBuilder.latencyHistogram)
 	assert.NotNil(t, _assertsProcessor.metricBuilder.sampledTraceCount)
+	assert.NotNil(t, _assertsProcessor.metricBuilder.totalTraceCount)
 	assert.NotNil(t, _assertsProcessor.metricBuilder.requestContextsByService)
 
 	// Sampler

--- a/assertsprocessor/factory_test.go
+++ b/assertsprocessor/factory_test.go
@@ -64,6 +64,7 @@ func TestCreateProcessor(t *testing.T) {
 	assert.NotNil(t, _assertsProcessor.metricBuilder.prometheusRegistry)
 	assert.NotNil(t, _assertsProcessor.metricBuilder.spanMatcher)
 	assert.NotNil(t, _assertsProcessor.metricBuilder.latencyHistogram)
+	assert.NotNil(t, _assertsProcessor.metricBuilder.sampledTraceCount)
 	assert.NotNil(t, _assertsProcessor.metricBuilder.requestContextsByService)
 
 	// Sampler
@@ -74,6 +75,8 @@ func TestCreateProcessor(t *testing.T) {
 	assert.NotNil(t, _assertsProcessor.sampler.topTracesByService)
 	assert.NotNil(t, _assertsProcessor.sampler.traceFlushTicker)
 	assert.NotNil(t, _assertsProcessor.sampler.spanMatcher)
+	assert.NotNil(t, _assertsProcessor.sampler.metricHelper)
+	assert.Equal(t, _assertsProcessor.metricBuilder, _assertsProcessor.sampler.metricHelper)
 
 	// Threshold Helper
 	assert.Equal(t, config, *_assertsProcessor.sampler.thresholdHelper.config)

--- a/assertsprocessor/metrics.go
+++ b/assertsprocessor/metrics.go
@@ -69,8 +69,11 @@ func (p *metricHelper) init() error {
 	sort.Strings(spanMetricLabels)
 	p.logger.Info("Latency Histogram with ", zap.String("labels", strings.Join(spanMetricLabels, ", ")))
 
+	sort.Strings(serviceKeyLabels)
+	p.logger.Info("Total Trace Counter with ", zap.String("labels", strings.Join(serviceKeyLabels, ", ")))
+
 	sort.Strings(sampledTraceCountLabels)
-	p.logger.Info("Sampled Trace Count Counter with ", zap.String("labels", strings.Join(sampledTraceCountLabels, ", ")))
+	p.logger.Info("Sampled Trace Counter with ", zap.String("labels", strings.Join(sampledTraceCountLabels, ", ")))
 
 	// Start the prometheus server on port 9465
 	p.prometheusRegistry = prometheus.NewRegistry()

--- a/assertsprocessor/metrics_test.go
+++ b/assertsprocessor/metrics_test.go
@@ -9,6 +9,24 @@ import (
 	"testing"
 )
 
+func TestInit(t *testing.T) {
+	logger, _ := zap.NewProduction()
+	p := newMetricHelper(
+		logger,
+		&Config{
+			Env:  "dev",
+			Site: "us-west-2",
+			CaptureAttributesInMetric: []string{"rpc.system", "rpc.service", "rpc.method",
+				"aws.table.name", "aws.queue.url", "host.name"},
+		},
+		&spanMatcher{},
+	)
+	assert.Nil(t, p.init())
+	assert.NotNil(t, p.prometheusRegistry)
+	assert.NotNil(t, p.latencyHistogram)
+	assert.NotNil(t, p.sampledTraceCount)
+}
+
 func TestBuildLabels(t *testing.T) {
 	logger, _ := zap.NewProduction()
 	p := newMetricHelper(

--- a/assertsprocessor/metrics_test.go
+++ b/assertsprocessor/metrics_test.go
@@ -25,6 +25,7 @@ func TestInit(t *testing.T) {
 	assert.NotNil(t, p.prometheusRegistry)
 	assert.NotNil(t, p.latencyHistogram)
 	assert.NotNil(t, p.sampledTraceCount)
+	assert.NotNil(t, p.totalTraceCount)
 }
 
 func TestBuildLabels(t *testing.T) {

--- a/assertsprocessor/processor_test.go
+++ b/assertsprocessor/processor_test.go
@@ -106,6 +106,7 @@ func TestConsumeTraces(t *testing.T) {
 			traceFlushTicker:   clock.FromContext(ctx).NewTicker(time.Minute),
 			thresholdHelper:    &_th,
 			spanMatcher:        &spanMatcher{},
+			metricHelper:       buildMetricHelper(),
 		},
 	}
 

--- a/assertsprocessor/sampler.go
+++ b/assertsprocessor/sampler.go
@@ -12,7 +12,11 @@ import (
 )
 
 const (
-	AssertsRequestContextAttribute = "asserts.request.context"
+	AssertsRequestContextAttribute  = "asserts.request.context"
+	AssertsTraceSampleTypeAttribute = "asserts.sample.type"
+	AssertsTraceSampleTypeNormal    = "normal"
+	AssertsTraceSampleTypeSlow      = "slow"
+	AssertsTraceSampleTypeError     = "error"
 )
 
 type traceSampler struct {
@@ -37,6 +41,7 @@ type sampler struct {
 	nextConsumer       consumer.Traces
 	stop               chan bool
 	spanMatcher        *spanMatcher
+	metricHelper       *metricHelper
 }
 
 func (s *sampler) startProcessing() {
@@ -73,9 +78,16 @@ func (s *sampler) sampleTraces(ctx context.Context, traces *resourceTraces) {
 			ctx:     &ctx,
 			latency: traceStruct.latency,
 		}
+		sampledTraceCountLabels := map[string]string{
+			envLabel:       s.config.Env,
+			siteLabel:      s.config.Site,
+			namespaceLabel: traces.namespace,
+			serviceLabel:   traces.service,
+		}
 		if traceStruct.hasError() {
 			// For all the spans which have error, add the request context
 			traceStruct.getMainSpan().Attributes().PutStr(AssertsRequestContextAttribute, request)
+			traceStruct.getMainSpan().Attributes().PutStr(AssertsTraceSampleTypeAttribute, AssertsTraceSampleTypeError)
 			for _, span := range traceStruct.exitSpans {
 				if spanHasError(span) {
 					span.Attributes().PutStr(AssertsRequestContextAttribute, request)
@@ -88,8 +100,10 @@ func (s *sampler) sampleTraces(ctx context.Context, traces *resourceTraces) {
 				zap.String("request", traceStruct.requestKey.request),
 				zap.Float64("latency", traceStruct.latency))
 			requestState.errorQueue.push(&item)
+			sampledTraceCountLabels[traceSampleTypeLabel] = AssertsTraceSampleTypeError
 		} else if traceStruct.isSlow {
 			traceStruct.getMainSpan().Attributes().PutStr(AssertsRequestContextAttribute, request)
+			traceStruct.getMainSpan().Attributes().PutStr(AssertsTraceSampleTypeAttribute, AssertsTraceSampleTypeSlow)
 
 			s.logger.Debug("Capturing slow trace",
 				zap.String("traceId", traceStruct.getMainSpan().TraceID().String()),
@@ -98,13 +112,21 @@ func (s *sampler) sampleTraces(ctx context.Context, traces *resourceTraces) {
 				zap.Float64("latencyThreshold", traceStruct.latencyThreshold),
 				zap.Float64("latency", traceStruct.latency))
 			requestState.slowQueue.push(&item)
+			sampledTraceCountLabels[traceSampleTypeLabel] = AssertsTraceSampleTypeError
 		} else {
-			s.captureNormalSample(&item)
+			if s.captureNormalSample(&item) {
+				sampledTraceCountLabels[traceSampleTypeLabel] = AssertsTraceSampleTypeNormal
+			}
+		}
+
+		if sampledTraceCountLabels[traceSampleTypeLabel] != "" {
+			s.metricHelper.sampledTraceCount.With(sampledTraceCountLabels).Inc()
 		}
 	}
 }
 
-func (s *sampler) captureNormalSample(item *Item) {
+func (s *sampler) captureNormalSample(item *Item) bool {
+	sampled := false
 	// Capture healthy samples based on configured sampling rate
 	entityKeyString := item.trace.requestKey.entityKey.AsString()
 	request := item.trace.requestKey.request
@@ -130,6 +152,7 @@ func (s *sampler) captureNormalSample(item *Item) {
 			samplingState = samplingStateKV.Value()
 		}
 		if samplingState.sample(s.config.NormalSamplingFrequencyMinutes) {
+			sampled = true
 			s.logger.Debug("Capturing normal trace",
 				zap.String("traceId", item.trace.getMainSpan().TraceID().String()),
 				zap.String("entity", entityKeyString),
@@ -138,6 +161,8 @@ func (s *sampler) captureNormalSample(item *Item) {
 
 			// Capture request context as attribute and push to the latency queue to prioritize the healthy sample too
 			item.trace.getMainSpan().Attributes().PutStr(AssertsRequestContextAttribute, request)
+			item.trace.getMainSpan().Attributes().PutStr(AssertsTraceSampleTypeAttribute, AssertsTraceSampleTypeNormal)
+
 			requestState.slowQueue.push(item)
 		}
 	} else {
@@ -146,6 +171,7 @@ func (s *sampler) captureNormalSample(item *Item) {
 			zap.String("request context", request),
 		)
 	}
+	return sampled
 }
 
 func (s *sampler) updateTrace(namespace string, service string, trace *traceStruct) {

--- a/assertsprocessor/sampler.go
+++ b/assertsprocessor/sampler.go
@@ -84,6 +84,7 @@ func (s *sampler) sampleTraces(ctx context.Context, traces *resourceTraces) {
 			namespaceLabel: traces.namespace,
 			serviceLabel:   traces.service,
 		}
+		s.metricHelper.totalTraceCount.With(sampledTraceCountLabels).Inc()
 		if traceStruct.hasError() {
 			// For all the spans which have error, add the request context
 			traceStruct.getMainSpan().Attributes().PutStr(AssertsRequestContextAttribute, request)

--- a/assertsprocessor/sampler.go
+++ b/assertsprocessor/sampler.go
@@ -113,7 +113,7 @@ func (s *sampler) sampleTraces(ctx context.Context, traces *resourceTraces) {
 				zap.Float64("latencyThreshold", traceStruct.latencyThreshold),
 				zap.Float64("latency", traceStruct.latency))
 			requestState.slowQueue.push(&item)
-			sampledTraceCountLabels[traceSampleTypeLabel] = AssertsTraceSampleTypeError
+			sampledTraceCountLabels[traceSampleTypeLabel] = AssertsTraceSampleTypeSlow
 		} else {
 			if s.captureNormalSample(&item) {
 				sampledTraceCountLabels[traceSampleTypeLabel] = AssertsTraceSampleTypeNormal

--- a/assertsprocessor/sampler_test.go
+++ b/assertsprocessor/sampler_test.go
@@ -527,5 +527,11 @@ func buildMetricHelper() *metricHelper {
 		Subsystem: "trace",
 		Name:      "sampled_count_total",
 	}, []string{envLabel, siteLabel, namespaceLabel, serviceLabel, traceSampleTypeLabel})
+
+	m.totalTraceCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "asserts",
+		Subsystem: "trace",
+		Name:      "count_total",
+	}, []string{envLabel, siteLabel, namespaceLabel, serviceLabel})
 	return m
 }


### PR DESCRIPTION
[ch15371]

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/18289983/232004923-3d3f4297-769b-41f9-91c7-176a3a852ac2.png">

<img width="1773" alt="image" src="https://user-images.githubusercontent.com/18289983/232019535-ecdb79a0-410c-440c-b905-7d99a817a0dc.png">

<img width="1788" alt="image" src="https://user-images.githubusercontent.com/18289983/232021810-ded95e07-168f-4065-8078-1f75ae53fa5a.png">

It should suffice to determine the trace reduction factor at the service level instead of the request context level
