### PR TITLE
Map Config struct using both json andmapstructure

### DIFF
--- a/assertsprocessor/config.go
+++ b/assertsprocessor/config.go
@@ -6,27 +6,27 @@ import (
 )
 
 type MatcherDto struct {
-	SpanKind    string `json:"span_kind"`
-	AttrName    string `json:"attr_name"`
-	Regex       string `json:"regex"`
-	Replacement string `json:"replacement"`
+	SpanKind    string `mapstructure:"span_kind" json:"span_kind"`
+	AttrName    string `mapstructure:"attr_name" json:"attr_name"`
+	Regex       string `mapstructure:"regex" json:"regex"`
+	Replacement string `mapstructure:"replacement" json:"replacement"`
 }
 
 type Config struct {
-	AssertsServer                  *map[string]string            `json:"asserts_server"`
-	Env                            string                        `json:"asserts_env"`
-	Site                           string                        `json:"asserts_site"`
-	CaptureMetrics                 bool                          `json:"capture_metrics"`
-	RequestContextExps             map[string][]*MatcherDto      `json:"request_context_regex"`
-	ErrorTypeConfigs               map[string][]*ErrorTypeConfig `json:"error_type_config"`
-	CaptureAttributesInMetric      []string                      `json:"attributes_as_metric_labels"`
-	DefaultLatencyThreshold        float64                       `json:"sampling_latency_threshold_seconds"`
-	LimitPerService                int                           `json:"trace_rate_limit_per_service"`
-	LimitPerRequestPerService      int                           `json:"trace_rate_limit_per_service_per_request"`
-	RequestContextCacheTTL         int                           `json:"request_context_cache_ttl_minutes"`
-	NormalSamplingFrequencyMinutes int                           `json:"normal_trace_sampling_rate_minutes"`
-	PrometheusExporterPort         uint64                        `json:"prometheus_exporter_port"`
-	TraceFlushFrequencySeconds     int                           `json:"trace_flush_frequency_seconds"`
+	AssertsServer                  *map[string]string            `mapstructure:"asserts_server" json:"asserts_server"`
+	Env                            string                        `mapstructure:"asserts_env" json:"asserts_env"`
+	Site                           string                        `mapstructure:"asserts_site" json:"asserts_site"`
+	CaptureMetrics                 bool                          `mapstructure:"capture_metrics" json:"capture_metrics"`
+	RequestContextExps             map[string][]*MatcherDto      `mapstructure:"request_context_regex" json:"request_context_regex"`
+	ErrorTypeConfigs               map[string][]*ErrorTypeConfig `mapstructure:"error_type_config" json:"error_type_config"`
+	CaptureAttributesInMetric      []string                      `mapstructure:"attributes_as_metric_labels" json:"attributes_as_metric_labels"`
+	DefaultLatencyThreshold        float64                       `mapstructure:"sampling_latency_threshold_seconds" json:"sampling_latency_threshold_seconds"`
+	LimitPerService                int                           `mapstructure:"trace_rate_limit_per_service" json:"trace_rate_limit_per_service"`
+	LimitPerRequestPerService      int                           `mapstructure:"trace_rate_limit_per_service_per_request" json:"trace_rate_limit_per_service_per_request"`
+	RequestContextCacheTTL         int                           `mapstructure:"request_context_cache_ttl_minutes" json:"request_context_cache_ttl_minutes"`
+	NormalSamplingFrequencyMinutes int                           `mapstructure:"normal_trace_sampling_rate_minutes" json:"normal_trace_sampling_rate_minutes"`
+	PrometheusExporterPort         uint64                        `mapstructure:"prometheus_exporter_port" json:"prometheus_exporter_port"`
+	TraceFlushFrequencySeconds     int                           `mapstructure:"trace_flush_frequency_seconds" json:"trace_flush_frequency_seconds"`
 }
 
 // Validate implements the component.ConfigValidator interface.

--- a/assertsprocessor/config.go
+++ b/assertsprocessor/config.go
@@ -6,27 +6,27 @@ import (
 )
 
 type MatcherDto struct {
-	SpanKind    string `mapstructure:"span_kind"`
-	AttrName    string `mapstructure:"attr_name"`
-	Regex       string `mapstructure:"regex"`
-	Replacement string `mapstructure:"replacement"`
+	SpanKind    string `json:"span_kind"`
+	AttrName    string `json:"attr_name"`
+	Regex       string `json:"regex"`
+	Replacement string `json:"replacement"`
 }
 
 type Config struct {
-	AssertsServer                  *map[string]string            `mapstructure:"asserts_server"`
-	Env                            string                        `mapstructure:"asserts_env"`
-	Site                           string                        `mapstructure:"asserts_site"`
-	CaptureMetrics                 bool                          `mapstructure:"capture_metrics"`
-	RequestContextExps             map[string][]*MatcherDto      `mapstructure:"request_context_regex"`
-	ErrorTypeConfigs               map[string][]*ErrorTypeConfig `mapstructure:"error_type_config"`
-	CaptureAttributesInMetric      []string                      `mapstructure:"attributes_as_metric_labels"`
-	DefaultLatencyThreshold        float64                       `mapstructure:"sampling_latency_threshold_seconds"`
-	LimitPerService                int                           `mapstructure:"trace_rate_limit_per_service"`
-	LimitPerRequestPerService      int                           `mapstructure:"trace_rate_limit_per_service_per_request"`
-	RequestContextCacheTTL         int                           `mapstructure:"request_context_cache_ttl_minutes"`
-	NormalSamplingFrequencyMinutes int                           `mapstructure:"normal_trace_sampling_rate_minutes"`
-	PrometheusExporterPort         uint64                        `mapstructure:"prometheus_exporter_port"`
-	TraceFlushFrequencySeconds     int                           `mapstructure:"trace_flush_frequency_seconds"`
+	AssertsServer                  *map[string]string            `json:"asserts_server"`
+	Env                            string                        `json:"asserts_env"`
+	Site                           string                        `json:"asserts_site"`
+	CaptureMetrics                 bool                          `json:"capture_metrics"`
+	RequestContextExps             map[string][]*MatcherDto      `json:"request_context_regex"`
+	ErrorTypeConfigs               map[string][]*ErrorTypeConfig `json:"error_type_config"`
+	CaptureAttributesInMetric      []string                      `json:"attributes_as_metric_labels"`
+	DefaultLatencyThreshold        float64                       `json:"sampling_latency_threshold_seconds"`
+	LimitPerService                int                           `json:"trace_rate_limit_per_service"`
+	LimitPerRequestPerService      int                           `json:"trace_rate_limit_per_service_per_request"`
+	RequestContextCacheTTL         int                           `json:"request_context_cache_ttl_minutes"`
+	NormalSamplingFrequencyMinutes int                           `json:"normal_trace_sampling_rate_minutes"`
+	PrometheusExporterPort         uint64                        `json:"prometheus_exporter_port"`
+	TraceFlushFrequencySeconds     int                           `json:"trace_flush_frequency_seconds"`
 }
 
 // Validate implements the component.ConfigValidator interface.

--- a/assertsprocessor/config_refresh_test.go
+++ b/assertsprocessor/config_refresh_test.go
@@ -29,11 +29,11 @@ func TestFetchConfig(t *testing.T) {
 
 	mockClient := &mockRestClient{
 		expectedData: []byte(`{
-			"CaptureMetrics": true,
-			"RequestContextExps": {"default":[{"AttrName":"attribute1","Regex":"(Foo).+","Replacement":"$1"}]},
-			"CaptureAttributesInMetric": ["rpc.system", "rpc.service"],
-			"DefaultLatencyThreshold": 0.51,
-			"Unknown": "foo"
+			"capture_metrics": true,
+			"request_context_regex": {"default":[{"attr_name":"attribute1","regex":"(Foo).+","replacement":"$1"}]},
+			"attributes_as_metric_labels": ["rpc.system", "rpc.service"],
+			"sampling_latency_threshold_seconds": 0.51,
+			"unknown": "foo"
 		}`),
 		expectedErr: nil,
 	}
@@ -145,7 +145,7 @@ func TestUpdateConfigError(t *testing.T) {
 func TestFetchAndUpdateConfig(t *testing.T) {
 	mockClient := &mockRestClient{
 		expectedData: []byte(`{
-			"DefaultLatencyThreshold": 0.51
+			"sampling_latency_threshold_seconds": 0.51
 		}`),
 		expectedErr: nil,
 	}

--- a/assertsprocessor/factory_test.go
+++ b/assertsprocessor/factory_test.go
@@ -116,10 +116,10 @@ func TestCreateProcessorMergeFetchedConfig(t *testing.T) {
 
 	mockClient := &mockRestClient{
 		expectedData: []byte(`{
-			"CaptureMetrics": true,
-			"RequestContextExps": {"default":[{"AttrName":"attribute1","Regex":"+","Replacement":"$1"}]},
-			"CaptureAttributesInMetric": ["rpc.system", "rpc.service"],
-			"DefaultLatencyThreshold": 0.51
+			"capture_metrics": true,
+			"request_context_regex": {"default":[{"attr_name":"attribute1","regex":"+","replacement":"$1"}]},
+			"attributes_as_metric_labels": ["rpc.system", "rpc.service"],
+			"sampling_latency_threshold_seconds": 0.51
 		}`),
 		expectedErr: nil,
 	}


### PR DESCRIPTION
The initial read of the config by the collector uses `mapstructure`. But when reading the response from the API, the unmarshal doesn't work with the `mapstructure`. Adding `json` mapping fixes this 