### PR TITLE
Collector ECS support

### DIFF
--- a/Dockerfile.all-exporters
+++ b/Dockerfile.all-exporters
@@ -1,0 +1,21 @@
+FROM amazonlinux:2
+
+WORKDIR /opt/asserts
+COPY asserts-otel-collector /opt/asserts
+COPY start-collector.sh /opt/asserts
+
+WORKDIR /etc/asserts
+COPY config/collector-config-otlp.yaml /etc/asserts
+COPY config/collector-config-otlphttp.yaml /etc/asserts
+COPY config/collector-config-cloudtrace.yaml /etc/asserts
+COPY config/collector-config-aws-xray.yaml /etc/asserts
+
+EXPOSE 8888
+EXPOSE 8889
+EXPOSE 9465
+EXPOSE 4317
+EXPOSE 4318
+EXPOSE 14278
+EXPOSE 14250
+
+ENTRYPOINT /opt/asserts/start-collector.sh

--- a/config/collector-config-aws-xray.yaml
+++ b/config/collector-config-aws-xray.yaml
@@ -1,0 +1,65 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  awsxray:
+    index_all_attributes: true
+
+  prometheus:
+    namespace: default
+    endpoint: 0.0.0.0:8889
+
+processors:
+  assertsprocessor:
+    asserts_server:
+      endpoint: $ASSERTS_SERVER_API_ENDPOINT
+      user: $ASSERTS_SERVER_USERNAME
+      password: $ASSERTS_SERVER_PASSWORD
+    asserts_env: $ASSERTS_ENV
+    asserts_site: $ASSERTS_SITE
+    capture_metrics: true
+    custom_attributes:
+      "asserts.error.type":
+        "default":
+          - value_expr: client_errors
+            regex: 4..
+            source_attributes: ["http.status_code"]
+            span_kinds: ["Client", "Server"]
+          - value_expr: server_errors
+            regex: 5..
+            source_attributes: ["http.status_code"]
+            span_kinds: ["Client", "Server"]
+      "asserts.request.context":
+        default:
+          - source_attributes: ["http.route"]
+            regex: "(.+)"
+            span_kinds: ["Server"]
+          - source_attributes: ["http.url"]
+            span_kinds: ["Server", "Client"]
+            regex: "https?://.+?((/[^/?]+){1,2}).*"
+    attributes_as_metric_labels:
+      - "rpc.system"
+      - "rpc.service"
+      - "rpc.method"
+      - "aws.table.name"
+      - "aws.queue.url"
+      - "aws.bucket.name"
+      - "db.operation"
+      - "db.system"
+service:
+  telemetry:
+    logs:
+      level: $LOG_LEVEL
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [assertsprocessor]
+      exporters: [awsxray]
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus]

--- a/config/collector-config-cloudtrace.yaml
+++ b/config/collector-config-cloudtrace.yaml
@@ -1,0 +1,70 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  googlecloud:
+  googlecloud/customname:
+    project: $GCP_PROJECT_NAME
+    log:
+      default_log_name: opentelemetry.io/collector-exported-log
+  prometheus:
+    namespace: default
+    endpoint: 0.0.0.0:8889
+
+processors:
+  resourcedetection:
+    detectors: [gcp]
+    timeout: 10s
+  assertsprocessor:
+    asserts_server:
+      endpoint: $ASSERTS_SERVER_API_ENDPOINT
+      user: $ASSERTS_SERVER_USERNAME
+      password: $ASSERTS_SERVER_PASSWORD
+    asserts_env: $ASSERTS_ENV
+    asserts_site: $ASSERTS_SITE
+    capture_metrics: true
+    custom_attributes:
+      "asserts.error.type":
+        "default":
+          - value_expr: client_errors
+            regex: 4..
+            source_attributes: ["http.status_code"]
+            span_kinds: ["Client", "Server"]
+          - value_expr: server_errors
+            regex: 5..
+            source_attributes: ["http.status_code"]
+            span_kinds: ["Client", "Server"]
+      "asserts.request.context":
+        default:
+          - source_attributes: ["http.route"]
+            regex: "(.+)"
+            span_kinds: ["Server"]
+          - source_attributes: ["http.url"]
+            span_kinds: ["Server", "Client"]
+            regex: "https?://.+?((/[^/?]+){1,2}).*"
+    attributes_as_metric_labels:
+      - "rpc.system"
+      - "rpc.service"
+      - "rpc.method"
+      - "aws.table.name"
+      - "aws.queue.url"
+      - "aws.bucket.name"
+      - "db.operation"
+      - "db.system"
+service:
+  telemetry:
+    logs:
+      level: $LOG_LEVEL
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [assertsprocessor]
+      exporters: [googlecloud]
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus]

--- a/config/collector-config-otlp.yaml
+++ b/config/collector-config-otlp.yaml
@@ -1,0 +1,66 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  otlp:
+    endpoint: $OTLP_ENDPOINT
+    tls:
+      insecure: true
+  prometheus:
+    namespace: default
+    endpoint: 0.0.0.0:8889
+
+processors:
+  assertsprocessor:
+    asserts_server:
+      endpoint: $ASSERTS_SERVER_API_ENDPOINT
+      user: $ASSERTS_SERVER_USERNAME
+      password: $ASSERTS_SERVER_PASSWORD
+    asserts_env: $ASSERTS_ENV
+    asserts_site: $ASSERTS_SITE
+    capture_metrics: true
+    custom_attributes:
+      "asserts.error.type":
+        "default":
+          - value_expr: client_errors
+            regex: 4..
+            source_attributes: ["http.status_code"]
+            span_kinds: ["Client", "Server"]
+          - value_expr: server_errors
+            regex: 5..
+            source_attributes: ["http.status_code"]
+            span_kinds: ["Client", "Server"]
+      "asserts.request.context":
+        default:
+          - source_attributes: ["http.route"]
+            regex: "(.+)"
+            span_kinds: ["Server"]
+          - source_attributes: ["http.url"]
+            span_kinds: ["Server", "Client"]
+            regex: "https?://.+?((/[^/?]+){1,2}).*"
+    attributes_as_metric_labels:
+      - "rpc.system"
+      - "rpc.service"
+      - "rpc.method"
+      - "aws.table.name"
+      - "aws.queue.url"
+      - "aws.bucket.name"
+      - "db.operation"
+      - "db.system"
+service:
+  telemetry:
+    logs:
+      level: $LOG_LEVEL
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [assertsprocessor]
+      exporters: [otlp]
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus]

--- a/config/collector-config-otlphttp.yaml
+++ b/config/collector-config-otlphttp.yaml
@@ -1,0 +1,66 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  otlphttp:
+    endpoint: $OTLP_ENDPOINT
+    tls:
+      insecure: true
+  prometheus:
+    namespace: default
+    endpoint: 0.0.0.0:8889
+
+processors:
+  assertsprocessor:
+    asserts_server:
+      endpoint: $ASSERTS_SERVER_API_ENDPOINT
+      user: $ASSERTS_SERVER_USERNAME
+      password: $ASSERTS_SERVER_PASSWORD
+    asserts_env: $ASSERTS_ENV
+    asserts_site: $ASSERTS_SITE
+    capture_metrics: true
+    custom_attributes:
+      "asserts.error.type":
+        "default":
+          - value_expr: client_errors
+            regex: 4..
+            source_attributes: ["http.status_code"]
+            span_kinds: ["Client", "Server"]
+          - value_expr: server_errors
+            regex: 5..
+            source_attributes: ["http.status_code"]
+            span_kinds: ["Client", "Server"]
+      "asserts.request.context":
+        default:
+          - source_attributes: ["http.route"]
+            regex: "(.+)"
+            span_kinds: ["Server"]
+          - source_attributes: ["http.url"]
+            span_kinds: ["Server", "Client"]
+            regex: "https?://.+?((/[^/?]+){1,2}).*"
+    attributes_as_metric_labels:
+      - "rpc.system"
+      - "rpc.service"
+      - "rpc.method"
+      - "aws.table.name"
+      - "aws.queue.url"
+      - "aws.bucket.name"
+      - "db.operation"
+      - "db.system"
+service:
+  telemetry:
+    logs:
+      level: $LOG_LEVEL
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [assertsprocessor]
+      exporters: [otlphttp]
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus]

--- a/deployment/ecs/otel-collector-alb.yaml
+++ b/deployment/ecs/otel-collector-alb.yaml
@@ -1,0 +1,166 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Asserts OTEL Collector ALB Stack
+Parameters:
+  AssertsEnvironment:
+    Type: String
+    Description: The installation environment name
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: "Id of VPC in which Asserts OTEL Collector is being installed"
+  ALBSubnets:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: "The IDs of the subnets on which the OTEL Collector ALB should be installed."
+  ALBSecurityGroupId:
+    Type: String
+Resources:
+  OTELCollectorALB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Join [ "-", [ "Asserts-OTEL-Collector", !Ref AssertsEnvironment ] ]
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "Asserts OTEL Collector"
+        - Key: Environment
+          Value: !Ref AssertsEnvironment
+      Scheme: internet-facing
+      Subnets: !Ref ALBSubnets
+      SecurityGroups:
+        - !Ref ALBSecurityGroupId
+      Type: application
+      IpAddressType: "ipv4"
+      LoadBalancerAttributes:
+        - Key: "access_logs.s3.enabled"
+          Value: "false"
+        - Key: "idle_timeout.timeout_seconds"
+          Value: "60"
+        - Key: "deletion_protection.enabled"
+          Value: "false"
+        - Key: "routing.http2.enabled"
+          Value: "true"
+        - Key: "routing.http.drop_invalid_header_fields.enabled"
+          Value: "false"
+
+#  OTELCollectorGRPCTargetGroup:
+#    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+#    Properties:
+#      Port: 4317
+#      Protocol: HTTP
+#      ProtocolVersion: gRPC
+#      Tags:
+#        - Key: Vendor
+#          Value: Asserts
+#        - Key: "asserts:component"
+#          Value: "Asserts OTEL Collector"
+#        - Key: Environment
+#          Value: !Ref AssertsEnvironment
+#      TargetType: ip
+#      VpcId: !Ref VpcId
+
+  OTELCollectorHTTPTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Port: 4318
+      Protocol: HTTP
+      HealthCheckEnabled: true
+      HealthCheckIntervalSeconds: 30
+      HealthCheckPath: "/metrics"
+      HealthCheckProtocol: "HTTP"
+      HealthCheckPort: 9465
+      HealthCheckTimeoutSeconds: 15
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 10
+      Matcher:
+        HttpCode: 200
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "Asserts OTEL Collector"
+        - Key: Environment
+          Value: !Ref AssertsEnvironment
+      TargetType: ip
+      VpcId: !Ref VpcId
+
+  OTELCollectorALBHTTPListener:
+    Type: "AWS::ElasticLoadBalancingV2::Listener"
+    Properties:
+      LoadBalancerArn: !Ref OTELCollectorALB
+      Port: 4318
+      Protocol: HTTP
+      DefaultActions:
+        - Order: 1
+          Type: "forward"
+          ForwardConfig:
+            TargetGroups:
+              - TargetGroupArn: !Ref OTELCollectorHTTPTargetGroup
+                Weight: 1
+            TargetGroupStickinessConfig:
+              Enabled: false
+
+  OTELCollectorALBHTTPListenerRule:
+    Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
+    Properties:
+      Priority: "1"
+      ListenerArn: !Ref OTELCollectorALBHTTPListener
+      Conditions:
+        - Field: path-pattern
+          PathPatternConfig:
+            Values:
+              - "/v1/*"
+      Actions:
+        - Type: "forward"
+          TargetGroupArn: !Ref OTELCollectorHTTPTargetGroup
+          Order: 1
+          ForwardConfig:
+            TargetGroups:
+              - TargetGroupArn: !Ref OTELCollectorHTTPTargetGroup
+                Weight: 1
+            TargetGroupStickinessConfig:
+              Enabled: false
+
+#  OTELCollectorALBGRPCListener:
+#    Type: "AWS::ElasticLoadBalancingV2::Listener"
+#    Properties:
+#      LoadBalancerArn: !Ref OTELCollectorALB
+#      Port: 4317
+#      Protocol: HTTP
+#      DefaultActions:
+#        - Order: 1
+#          Type: "forward"
+#          ForwardConfig:
+#            TargetGroups:
+#              - TargetGroupArn: !Ref OTELCollectorGRPCTargetGroup
+#                Weight: 1
+#            TargetGroupStickinessConfig:
+#              Enabled: false
+#
+#  OTELCollectorALBGRPCListenerRule:
+#    Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
+#    Properties:
+#      Priority: "1"
+#      ListenerArn: !Ref OTELCollectorALBGRPCListener
+#      Conditions:
+#        - Field: path-pattern
+#          PathPatternConfig:
+#            Values:
+#              - "*"
+#      Actions:
+#        - Type: "forward"
+#          TargetGroupArn: !Ref OTELCollectorGRPCTargetGroup
+#          Order: 1
+#          ForwardConfig:
+#            TargetGroups:
+#              - TargetGroupArn: !Ref OTELCollectorGRPCTargetGroup
+#                Weight: 1
+#            TargetGroupStickinessConfig:
+#              Enabled: false
+Outputs:
+  ALBDNSName:
+    Description: "The DNS name for the load balancer."
+    Value: !GetAtt OTELCollectorALB.DNSName
+#  CollectorGRPCTargetGroupARN:
+#    Value: !Ref OTELCollectorGRPCTargetGroup
+  CollectorHTTPTargetGroupARN:
+    Value: !Ref OTELCollectorHTTPTargetGroup

--- a/deployment/ecs/otel-collector-ecs-service.yaml
+++ b/deployment/ecs/otel-collector-ecs-service.yaml
@@ -1,0 +1,170 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Asserts OTEL Collector Security Group Stack
+Parameters:
+  AssertsEnvironment:
+    Type: String
+    Description: The installation environment name
+  AssertsSite:
+    Type: String
+    Description: The installation site name
+  OTLPExportEndpoint:
+    Type: String
+    Description: OTLP Endpoint to export traces to
+  Cluster:
+    Type: String
+    Description: "Asserts OTEL Cluster"
+    Default: "asserts-otel"
+
+  ECSSubnets:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: "The IDs of the subnets on which the OTEL Collector ECS Tasks should be installed."
+
+  ECSSecurityGroupId:
+    Type: String
+
+  AssignPublicIPToECSTask:
+    Type: String
+    Description: Determines whether the ECS Task ENIs will be assigned a public IP
+    Default: "ENABLED"
+    AllowedValues: [ "ENABLED", "DISABLED" ]
+
+  AssertsOTELCollectorVersion:
+    Type: String
+    Description: "Asserts OTEL Collector Image version"
+    Default: docker.io/asserts/otel-collector:v0.0.78
+
+  AssertsApiServerURL:
+    Type: String
+    Description: Asserts ApiServer Username
+
+  AssertsApiServerUsername:
+    Type: String
+
+  AssertsApiServerPassword:
+    Type: String
+    NoEcho: true
+
+  NumCollectorInstances:
+    Type: String
+    Description: Number of Collector Instances to install
+
+  LogLevel:
+    Type: String
+    Default: info
+
+#  CollectorGRPCTargetGroupARN:
+#    Type: String
+
+  CollectorHTTPTargetGroupARN:
+    Type: String
+Resources:
+  OTELCollectorECSCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Join [ "-", [ !Ref Cluster, !Ref AssertsEnvironment ] ]
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "Asserts OTEL Collector"
+      ClusterSettings:
+        - Name: containerInsights
+          Value: disabled
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "Asserts OTEL Collector"
+      LogGroupName: !Join ["-", ["asserts-otel-collector" , !Ref AssertsEnvironment]]
+      RetentionInDays: 7
+
+  AssertsOTELCollectorService:
+    Type: AWS::ECS::Service
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "Asserts OTEL Collector"
+      Cluster: !Join [ "-", [ !Ref Cluster, !Ref AssertsEnvironment ] ]
+      ServiceName: !Join [ "-", [ "asserts-otel-collector", !Ref AssertsEnvironment ] ]
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 100
+      DeploymentController:
+        Type: ECS
+      LaunchType: FARGATE
+      DesiredCount: !Ref NumCollectorInstances
+      LoadBalancers:
+        - ContainerName: asserts-otel-collector
+          ContainerPort: 4318
+          TargetGroupArn: !Ref CollectorHTTPTargetGroupARN
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: !Ref AssignPublicIPToECSTask
+          SecurityGroups:
+            - !Ref ECSSecurityGroupId
+          Subnets: !Ref ECSSubnets
+      PlatformVersion: 1.4.0
+      PropagateTags: SERVICE
+      SchedulingStrategy: REPLICA
+      TaskDefinition:
+        Ref: AssertsOTELCollectorTaskDefinition
+
+  AssertsOTELCollectorTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "Asserts OTEL Collector"
+      Cpu: "2048"
+      ExecutionRoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/AssertsOTELECSExecutionRole-${AssertsEnvironment}"
+      TaskRoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/AssertsOTELECSTaskRole-${AssertsEnvironment}"
+      Family: !Sub "asserts-otel-${AssertsEnvironment}"
+      Memory: "4096"
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ContainerDefinitions:
+        - Essential: true
+          Image: !Ref AssertsOTELCollectorVersion
+          Name: asserts-otel-collector
+          LinuxParameters: { }
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Sub "asserts-otel-collector-${AssertsEnvironment}"
+              awslogs-region:
+                Ref: AWS::Region
+              awslogs-stream-prefix: asserts-otel-collector
+          PortMappings:
+            - ContainerPort: 4317
+              HostPort: 4317
+              Protocol: tcp
+            - ContainerPort: 4318
+              HostPort: 4318
+              Protocol: tcp
+          DockerLabels:
+            PROMETHEUS_EXPORTER_PORT: 8465
+            PROMETHEUS_EXPORTER_PATH: /metrics
+          Environment:
+            - Name: ASSERTS_SERVER_API_ENDPOINT
+              Value: !Ref AssertsApiServerURL
+            - Name: ASSERTS_ENV
+              Value: !Ref AssertsEnvironment
+            - Name: ASSERTS_SITE
+              Value: !Ref AssertsSite
+            - Name: TRACE_STORE
+              Value: AWS-XRAY
+            - Name: OTLP_ENDPOINT
+              Value: !Ref OTLPExportEndpoint
+            - Name: ASSERTS_SERVER_USERNAME
+              Value: !Ref AssertsApiServerUsername
+            - Name: ASSERTS_SERVER_PASSWORD
+              Value: !Ref AssertsApiServerPassword

--- a/deployment/ecs/otel-collector-iam.yaml
+++ b/deployment/ecs/otel-collector-iam.yaml
@@ -1,0 +1,162 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Asserts OTEL Collector IAM Stack
+Parameters:
+  AssertsEnvironment:
+    Type: String
+    Description: The installation environment name
+Resources:
+  AssertsOTELECSExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "AssertsOTELECSExecutionRole-${AssertsEnvironment}"
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "AWS Exporter"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+        - "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+      Policies:
+        - PolicyName: !Sub "AssertsOTELECSExecutionSecretsReadPolicy-${AssertsEnvironment}"
+          PolicyDocument: !Sub >
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "secretsmanager:GetSecretValue",
+                    "kms:Decrypt",
+                    "secretsmanager:DescribeSecret"
+                  ],
+                  "Resource": [
+                    "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:AssertsApiServerCredentials-${AssertsEnvironment}*"
+                  ]
+                },
+                {
+                  "Sid": "VisualEditor1",
+                  "Effect": "Allow",
+                  "Action": "secretsmanager:ListSecrets",
+                  "Resource": [
+                    "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:AssertsApiServerCredentials-${AssertsEnvironment}*"
+                  ]
+                }
+              ]
+            }
+        - PolicyName: !Sub "AssertsLogGroupReadWritePolicy-${AssertsEnvironment}"
+          PolicyDocument: !Sub >
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents"
+                  ],
+                  "Resource": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:asserts-otel-collector-${AssertsEnvironment}:*"
+                }
+              ]
+            }
+  AssertsOTELECSTaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "AssertsOTELECSTaskRole-${AssertsEnvironment}"
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "AWS Exporter"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess"
+      Policies:
+        - PolicyName: !Sub "AssertsOTELECSTaskSecretsReadPolicy-${AssertsEnvironment}"
+          PolicyDocument: !Sub >
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "secretsmanager:GetSecretValue",
+                    "kms:Decrypt",
+                    "secretsmanager:DescribeSecret"
+                  ],
+                  "Resource": [
+                    "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:AssertsApiServerCredentials-${AssertsEnvironment}*"
+                  ]
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": "secretsmanager:ListSecrets",
+                  "Resource": [
+                    "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:AssertsApiServerCredentials-${AssertsEnvironment}*"
+                  ]
+                }
+              ]
+            }
+        - PolicyName: !Sub "AssertsOTELCollectorRolePolicy-${AssertsEnvironment}"
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Resource: "*"
+                Action:
+                  - autoscaling:DescribeAutoScalingGroups
+                  - autoscaling:DescribeTags
+                  - autoscaling:DescribeLoadBalancers
+                  - dynamodb:ListTables
+                  - ec2:DescribeVolumes
+                  - ec2:DescribeInstances
+                  - ec2:DescribeSubnets
+                  - ecs:DescribeClusters
+                  - ecs:DescribeServices
+                  - ecs:DescribeTaskDefinition
+                  - ecs:DescribeTasks
+                  - ecs:ListAccountSettings
+                  - ecs:ListClusters
+                  - ecs:ListServices
+                  - ecs:ListTaskDefinitionFamilies
+                  - ecs:ListTaskDefinitions
+                  - elasticloadbalancing:DescribeListeners
+                  - elasticloadbalancing:DescribeLoadBalancers
+                  - elasticloadbalancing:DescribeRules
+                  - elasticloadbalancing:DescribeTags
+                  - elasticloadbalancing:DescribeTargetGroups
+                  - elasticloadbalancing:DescribeTargetHealth
+                  - firehose:ListDeliveryStreams
+                  - kinesis:ListStreamConsumers
+                  - kinesis:ListStreams
+                  - kinesis:ListTagsForStream
+                  - kinesisanalytics:ListApplications
+                  - lambda:GetAccountSettings
+                  - lambda:ListEventSourceMappings
+                  - lambda:ListFunctions
+                  - redshift:DescribeClusters
+                  - redshift:ListDatabases
+                  - redshift:ListTables
+                  - s3:ListAllMyBuckets
+                  - sns:ListTopics
+                  - sqs:ListQueues
+                  - tag:GetResources
+                  - elasticmapreduce:ListClusters
+                  - cloudwatch:DescribeAlarms
+                  - cloudwatch:GetMetricData
+                  - cloudwatch:ListMetrics

--- a/deployment/ecs/otel-collector-main.yaml
+++ b/deployment/ecs/otel-collector-main.yaml
@@ -1,0 +1,168 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Asserts OTEL Collector Stack
+Parameters:
+  AssertsEnvironment:
+    Type: String
+    Description: The installation environment name
+    Default: Dev
+
+  AssertsSite:
+    Type: String
+    Description: The installation site. For e.g. us-west-2
+    Default: us-west-2
+
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: "Id of VPC in which Asserts OTEL Collector is being installed"
+
+  ALBSubnets:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: "The IDs of the subnets on which the OTEL Collector ALB should be installed."
+
+  ALBIngressSourceCIDR:
+    Type: String
+    Description: "Source IP CIDR for ALB Ingress"
+    Default: 0.0.0.0/0
+
+  Cluster:
+    Type: String
+    Description: "Asserts OTEL Cluster"
+    Default: "asserts-otel"
+
+  ECSSubnets:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: "The IDs of the subnets on which the OTEL Collector ECS Tasks should be installed."
+
+  AssignPublicIPToECSTask:
+    Type: String
+    Description: Determines whether the ECS Task ENIs will be assigned a public IP
+    Default: "DISABLED"
+    AllowedValues: [ "ENABLED", "DISABLED" ]
+
+  AssertsOTELCollectorVersion:
+    Type: String
+    Description: "Asserts OTEL Collector Image version"
+    Default: asserts/otel-collector:v0.0.77-ecs
+
+  AssertsApiServerURL:
+    Type: String
+    Description: Asserts ApiServer Username
+    Default: https://chief.dev.app.asserts.ai
+
+  AssertsApiServerUsername:
+    Type: String
+
+  AssertsApiServerPassword:
+    Type: String
+    NoEcho: true
+
+  NumCollectorInstances:
+    Type: String
+    Description: Number of Collector Instances to install
+    Default: 1
+
+  OTLPExportEndpoint:
+    Type: String
+    Description: OTLP Export Endpoint
+    Default: jaeger.dev.asserts.ai
+
+  LogLevel:
+    Type: String
+    Default: info
+Metadata:
+  "AWS::CloudFormation::Interface":
+    ParameterGroups:
+      - Label: "Common Parameters"
+        Parameters:
+          - AssertsEnvironment
+          - AssertsSite
+          - VpcId
+      - Label: "ALB Parameters"
+        Parameters:
+          - ALBSubnets
+          - ALBIngressSourceCIDR
+      - Label: "ECS Parameters"
+        Parameters:
+          - Cluster
+          - ECSSubnets
+          - AssignPublicIPToECSTask
+          - AssertsOTELCollectorVersion
+          - AssertsApiServerURL
+          - AssertsApiServerUsername
+          - AssertsApiServerPassword
+          - OTLPExportEndpoint
+          - NumCollectorInstances
+Resources:
+  AssertsOTELIAMStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "OTEL Collector"
+      TemplateURL: https://s3.us-west-2.amazonaws.com/downloads.asserts.ai/asserts-otel-collector/ecs/v1/otel-collector-iam.yaml
+      TimeoutInMinutes: 30
+      Parameters:
+        AssertsEnvironment: !Ref AssertsEnvironment
+
+  AssertsOTELSecurityGroupStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "OTEL Collector"
+      TemplateURL: https://s3.us-west-2.amazonaws.com/downloads.asserts.ai/asserts-otel-collector/ecs/v1/otel-collector-security-groups.yaml
+      TimeoutInMinutes: 30
+      Parameters:
+        AssertsEnvironment: !Ref AssertsEnvironment
+        VpcId: !Ref VpcId
+        ALBIngressSourceCIDR: !Ref ALBIngressSourceCIDR
+
+  AssertsOTELALBStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "OTEL Collector"
+      TemplateURL: https://s3.us-west-2.amazonaws.com/downloads.asserts.ai/asserts-otel-collector/ecs/v1/otel-collector-alb.yaml
+      TimeoutInMinutes: 30
+      Parameters:
+        AssertsEnvironment: !Ref AssertsEnvironment
+        VpcId: !Ref VpcId
+        ALBSubnets: !Join [ ",", !Ref ALBSubnets ]
+        ALBSecurityGroupId: !GetAtt AssertsOTELSecurityGroupStack.Outputs.ALBSecurityGroupId
+
+  AssertsOTELECSStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "OTEL Collector"
+      TemplateURL: https://s3.us-west-2.amazonaws.com/downloads.asserts.ai/asserts-otel-collector/ecs/v1/otel-collector-ecs-service.yaml
+      TimeoutInMinutes: 30
+      Parameters:
+        AssertsEnvironment: !Ref AssertsEnvironment
+        AssertsSite: !Ref AssertsSite
+        Cluster: !Ref Cluster
+        ECSSubnets: !Join [ ",", !Ref ALBSubnets ]
+        AssignPublicIPToECSTask: !Ref AssignPublicIPToECSTask
+        AssertsOTELCollectorVersion: !Ref AssertsOTELCollectorVersion
+        AssertsApiServerURL: !Ref AssertsApiServerURL
+        AssertsApiServerUsername: !Ref AssertsApiServerUsername
+        AssertsApiServerPassword: !Ref AssertsApiServerPassword
+        NumCollectorInstances: !Ref NumCollectorInstances
+        ECSSecurityGroupId: !GetAtt AssertsOTELSecurityGroupStack.Outputs.ECSSecurityGroupId
+        CollectorHTTPTargetGroupARN: !GetAtt AssertsOTELALBStack.Outputs.CollectorHTTPTargetGroupARN
+        OTLPExportEndpoint: !Ref OTLPExportEndpoint
+        LogLevel: !Ref LogLevel
+Outputs:
+  OTELCollectorALBDNSName:
+    Description: "The DNS name for the load balancer."
+    Value: !GetAtt AssertsOTELALBStack.Outputs.ALBDNSName

--- a/deployment/ecs/otel-collector-security-groups.yaml
+++ b/deployment/ecs/otel-collector-security-groups.yaml
@@ -1,0 +1,101 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Asserts OTEL Collector Security Group Stack
+Parameters:
+  AssertsEnvironment:
+    Type: String
+    Description: The installation environment name
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: "Id of VPC in which Asserts OTEL Collector is being installed"
+  ALBIngressSourceCIDR:
+    Type: String
+    Description: "Source IP CIDR for ALB Ingress"
+Resources:
+  AssertsOTELCollectorALBSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "Asserts OTEL Collector"
+        - Key: Environment
+          Value: !Ref AssertsEnvironment
+      GroupDescription: "security group for ALB"
+      GroupName: !Join [ "-", [ "Asserts-OTEL-Collector-ALB-SG", !Ref AssertsEnvironment ] ]
+      VpcId: !Ref VpcId
+
+#  OTELCollectorALBGRPCIngress:
+#    Type: AWS::EC2::SecurityGroupIngress
+#    Properties:
+#      CidrIp: !Ref ALBIngressSourceCIDR
+#      Description: Allow HTTP
+#      FromPort: 4317
+#      IpProtocol: TCP
+#      ToPort: 4317
+#      GroupId:
+#        Ref: AssertsOTELCollectorALBSecurityGroup
+
+  OTELCollectorALBHTTPIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      CidrIp: !Ref ALBIngressSourceCIDR
+      Description: Allow HTTP
+      FromPort: 4318
+      IpProtocol: TCP
+      ToPort: 4318
+      GroupId:
+        Ref: AssertsOTELCollectorALBSecurityGroup
+
+  AssertsOTELCollectorSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "Asserts OTEL Collector"
+      GroupDescription: asserts-aws-integration Security Group for default network
+      GroupName: !Join [ "-", [ "Asserts-OTEL-SG", !Ref AssertsEnvironment ] ]
+      VpcId: !Ref VpcId
+
+#  ALBToCollectorGRPCIngress:
+#    Type: AWS::EC2::SecurityGroupIngress
+#    Properties:
+#      SourceSecurityGroupId: !Ref AssertsOTELCollectorSecurityGroup
+#      Description: otlp:4317/grpc
+#      FromPort: 4317
+#      GroupId:
+#        Ref: AssertsOTELCollectorSecurityGroup
+#      IpProtocol: TCP
+#      ToPort: 4317
+
+  ALBToCollectorHTTPIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      SourceSecurityGroupId: !Ref AssertsOTELCollectorALBSecurityGroup
+      Description: otlp:4318/http
+      FromPort: 4318
+      GroupId:
+        Ref: AssertsOTELCollectorSecurityGroup
+      IpProtocol: TCP
+      ToPort: 4318
+
+  CollectorScrapeIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      SourceSecurityGroupId: !Ref AssertsOTELCollectorALBSecurityGroup
+      Description: 9465/http
+      FromPort: 9465
+      GroupId:
+        Ref: AssertsOTELCollectorSecurityGroup
+      IpProtocol: TCP
+      ToPort: 9465
+
+Outputs:
+  ALBSecurityGroupId:
+    Description: "The DNS name for the load balancer."
+    Value: !GetAtt AssertsOTELCollectorALBSecurityGroup.GroupId
+  ECSSecurityGroupId:
+    Description: "The DNS name for the load balancer."
+    Value: !GetAtt AssertsOTELCollectorSecurityGroup.GroupId

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  asserts-otel-service:
+    build:
+      context: .
+      dockerfile: Dockerfile.ecs
+    image: asserts/otel-collector:v0.0.78
+    ports:
+      - "8888:8888"
+      - "8889:8889"
+      - "9465:9465"
+      - "4317:4317"
+      - "4318:4318"
+    env_file:
+      - ecs-test-env.properties

--- a/start-collector.sh
+++ b/start-collector.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ "$TRACE_STORE" == "OTLP-HTTP" ]; then
+    /opt/asserts/asserts-otel-collector --config /etc/asserts/collector-config-otlphttp.yaml
+elif [ "$TRACE_STORE" == "AWS-XRAY" ]; then
+    /opt/asserts/asserts-otel-collector --config /etc/asserts/collector-config-aws-xray.yaml
+elif [ "$TRACE_STORE" == "GOOGLE-CLOUDTRACE" ]; then
+    /opt/asserts/asserts-otel-collector --config /etc/asserts/collector-config-cloudtrace.yaml
+else
+    /opt/asserts/asserts-otel-collector --config /etc/asserts/collector-config-otlp.yaml
+fi
+
+


### PR DESCRIPTION
Asserts OTEL Collector ECS Support

* OTEL Collector can be setup as a ECS Task sidecar container
* OTEL Collector can be setup as an ECS Service with traces being sent to AWS X-Ray by default. We already have the ECS sidecar for resource metrics. So this will be better option as it avoids adding one more sidecar to the task.
* Supporting other trace stores in the ECS Service mode can be taken up later.
* Could only make it work with ECS service being on public subnets with public IP assignment for the tasks. Installation fails on private subnets. Can dig in later
* The credentials are in clear text for now. Will create a separate PR to make them secrets