### PR TITLE
Remove default values for env and site

### DIFF
--- a/assertsprocessor/config.go
+++ b/assertsprocessor/config.go
@@ -23,6 +23,11 @@ type Config struct {
 // Validate implements the component.ConfigValidator interface.
 // Checks for any invalid regexp
 func (config *Config) Validate() error {
+	if config.Env == "" {
+		return ValidationError{
+			message: fmt.Sprintf("Env property is not set"),
+		}
+	}
 	for targetAtt, byServiceKey := range config.CustomAttributeConfigs {
 		for serviceKey, configs := range byServiceKey {
 			for _, _config := range configs {

--- a/assertsprocessor/config_test.go
+++ b/assertsprocessor/config_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestValidateNoError(t *testing.T) {
 	dto := Config{
+		Env: "dev",
 		CustomAttributeConfigs: map[string]map[string][]*CustomAttributeConfig{
 			"asserts.request.context": {
 				"default": {
@@ -25,8 +26,29 @@ func TestValidateNoError(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestEnvMissing(t *testing.T) {
+	dto := Config{
+		CustomAttributeConfigs: map[string]map[string][]*CustomAttributeConfig{
+			"asserts.request.context": {
+				"default": {
+					{
+						SourceAttributes: []string{"attribute"},
+						SpanKinds:        []string{"Client"},
+						RegExp:           "(.+)",
+						Replacement:      "$1",
+					},
+				},
+			},
+		},
+	}
+	err := dto.Validate()
+	assert.NotNil(t, err)
+	assert.Equal(t, "Env property is not set", err.Error())
+}
+
 func TestValidateLimits(t *testing.T) {
 	dto := Config{
+		Env: "dev",
 		CustomAttributeConfigs: map[string]map[string][]*CustomAttributeConfig{
 			"asserts.request.context": {
 				"default": {

--- a/assertsprocessor/factory.go
+++ b/assertsprocessor/factory.go
@@ -33,8 +33,6 @@ func createDefaultConfig() component.Config {
 		AssertsServer: &map[string]string{
 			"endpoint": "https://chief.app.dev.asserts.ai",
 		},
-		Env:                            "dev",
-		Site:                           "us-west-2",
 		DefaultLatencyThreshold:        3,
 		LimitPerService:                100,
 		LimitPerRequestPerService:      3,

--- a/assertsprocessor/factory_test.go
+++ b/assertsprocessor/factory_test.go
@@ -18,7 +18,7 @@ type dummyConsumer struct {
 	consumer.Traces
 }
 
-func (dC dummyConsumer) ConsumeTraces(ctx context.Context, trace ptrace.Traces) error {
+func (dC dummyConsumer) ConsumeTraces(ctx context.Context, _ ptrace.Traces) error {
 	dC.items = append(dC.items, &Item{
 		ctx: &ctx,
 	})
@@ -34,8 +34,8 @@ func TestDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	var defaultConfig = factory.CreateDefaultConfig()
 	var pConfig = defaultConfig.(*Config)
-	assert.Equal(t, "dev", pConfig.Env)
-	assert.Equal(t, "us-west-2", pConfig.Site)
+	assert.Equal(t, "", pConfig.Env)
+	assert.Equal(t, "", pConfig.Site)
 	assert.Equal(t, 100, pConfig.LimitPerService)
 	assert.Equal(t, float64(3), pConfig.DefaultLatencyThreshold)
 }


### PR DESCRIPTION
[ch15731]

When `Site` is not set.

```
# HELP asserts_trace_count_total 
# TYPE asserts_trace_count_total counter
asserts_trace_count_total{asserts_env="dev",asserts_site="",namespace="AWS/ECS",service="ride-booking-service"} 36
```

When `Env` is not set

```
asserts-otel-processor git:(remove_env_site_defaults) ✗ ./asserts-otel-collector --config sample-collector-config.yaml
Error: invalid configuration: processors::assertsprocessor: Env property is not set
2023/06/01 17:56:45 collector server run finished with error: invalid configuration: processors::assertsprocessor: Env property is not set
```