### PR TITLE
Capture total and sampled span count metrics

### DIFF
--- a/assertsprocessor/factory.go
+++ b/assertsprocessor/factory.go
@@ -100,7 +100,7 @@ func newProcessor(logger *zap.Logger, ctx context.Context, config component.Conf
 		traceFlushTicker:   clock.FromContext(ctx).NewTicker(time.Duration(pConfig.TraceFlushFrequencySeconds) * time.Second),
 		nextConsumer:       nextConsumer,
 		stop:               make(chan bool),
-		metricHelper:       metricsHelper,
+		metrics:            metricsHelper.metrics,
 	}
 
 	p := &assertsProcessorImpl{

--- a/assertsprocessor/factory_test.go
+++ b/assertsprocessor/factory_test.go
@@ -66,10 +66,11 @@ func TestCreateProcessorDefaultConfig(t *testing.T) {
 	// Metric Builder
 	assert.Equal(t, config, *_assertsProcessor.metricBuilder.config)
 	assert.Equal(t, logger, _assertsProcessor.metricBuilder.logger)
-	assert.NotNil(t, _assertsProcessor.metricBuilder.prometheusRegistry)
-	assert.NotNil(t, _assertsProcessor.metricBuilder.latencyHistogram)
-	assert.NotNil(t, _assertsProcessor.metricBuilder.sampledTraceCount)
-	assert.NotNil(t, _assertsProcessor.metricBuilder.totalTraceCount)
+	assert.NotNil(t, _assertsProcessor.metricBuilder.metrics)
+	assert.NotNil(t, _assertsProcessor.metricBuilder.metrics.prometheusRegistry)
+	assert.NotNil(t, _assertsProcessor.metricBuilder.metrics.latencyHistogram)
+	assert.NotNil(t, _assertsProcessor.metricBuilder.metrics.sampledTraceCount)
+	assert.NotNil(t, _assertsProcessor.metricBuilder.metrics.totalTraceCount)
 	assert.NotNil(t, _assertsProcessor.metricBuilder.requestContextsByService)
 	assert.NotNil(t, _assertsProcessor.metricBuilder.rwMutex)
 
@@ -80,8 +81,8 @@ func TestCreateProcessorDefaultConfig(t *testing.T) {
 	assert.Equal(t, nextConsumer, _assertsProcessor.sampler.nextConsumer)
 	assert.NotNil(t, _assertsProcessor.sampler.topTracesByService)
 	assert.NotNil(t, _assertsProcessor.sampler.traceFlushTicker)
-	assert.NotNil(t, _assertsProcessor.sampler.metricHelper)
-	assert.Equal(t, _assertsProcessor.metricBuilder, _assertsProcessor.sampler.metricHelper)
+	assert.NotNil(t, _assertsProcessor.sampler.metrics)
+	assert.Equal(t, _assertsProcessor.metricBuilder.metrics, _assertsProcessor.sampler.metrics)
 
 	// Threshold Helper
 	assert.Equal(t, config, *_assertsProcessor.sampler.thresholdHelper.config)

--- a/assertsprocessor/metric_helper.go
+++ b/assertsprocessor/metric_helper.go
@@ -1,0 +1,244 @@
+package assertsprocessor
+
+import (
+	"context"
+	"errors"
+	"github.com/jellydator/ttlcache/v3"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/puzpuzpuz/xsync/v2"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	envLabel             = "asserts_env"
+	siteLabel            = "asserts_site"
+	namespaceLabel       = "namespace"
+	serviceLabel         = "service"
+	requestTypeLabel     = "asserts_request_type"
+	errorTypeLabel       = "asserts_error_type"
+	requestContextLabel  = "asserts_request_context"
+	spanKind             = "span_kind"
+	traceSampleTypeLabel = "sample_type"
+)
+
+type metricHelper struct {
+	logger     *zap.Logger
+	config     *Config
+	httpServer *http.Server
+	metrics    *metrics
+	exp        *metricsExporter
+	// limit cardinality of request contexts for which metrics are captured
+	requestContextsByService *xsync.MapOf[string, *ttlcache.Cache[string, prometheus.Labels]]
+	ttl                      time.Duration
+	// guard access to config.CaptureAttributesInMetric and latencyHistogram
+	rwMutex *sync.RWMutex
+}
+
+func newMetricHelper(logger *zap.Logger, config *Config) *metricHelper {
+	metrics := &metrics{
+		logger:             logger,
+		prometheusRegistry: prometheus.NewRegistry(),
+	}
+	exporter := &metricsExporter{
+		logger: logger,
+		config: config,
+	}
+	return &metricHelper{
+		logger:                   logger,
+		config:                   config,
+		ttl:                      time.Minute * time.Duration(config.RequestContextCacheTTL),
+		metrics:                  metrics,
+		exp:                      exporter,
+		requestContextsByService: xsync.NewMapOf[*ttlcache.Cache[string, prometheus.Labels]](),
+		rwMutex:                  &sync.RWMutex{},
+	}
+}
+
+func (p *metricHelper) recordLatency(labels prometheus.Labels, latencySeconds float64) {
+	p.rwMutex.RLock()
+	defer p.rwMutex.RUnlock()
+	p.metrics.latencyHistogram.With(labels).Observe(latencySeconds)
+}
+
+func (p *metricHelper) registerMetrics() error {
+	return p.metrics.registerMetrics(p.getAttributesAsLabels())
+}
+
+func (p *metricHelper) getAttributesAsLabels() []string {
+	attributes := make([]string, 0)
+	for _, att := range p.config.CaptureAttributesInMetric {
+		attributes = append(attributes, att)
+	}
+	attributes = append(attributes, AssertsRequestTypeAttribute)
+	attributes = append(attributes, AssertsRequestContextAttribute)
+	attributes = append(attributes, AssertsErrorTypeAttribute)
+	return attributes
+}
+
+func (p *metricHelper) captureMetrics(span *ptrace.Span, namespace string, service string,
+	resourceSpan *ptrace.ResourceSpans) {
+	serviceKey := getServiceKey(namespace, service)
+	attrValue, _ := span.Attributes().Get(AssertsRequestContextAttribute)
+	requestContext := attrValue.AsString()
+
+	cache, _ := p.requestContextsByService.LoadOrCompute(serviceKey, func() *ttlcache.Cache[string, prometheus.Labels] {
+		cache := ttlcache.New[string, prometheus.Labels](
+			ttlcache.WithTTL[string, prometheus.Labels](p.ttl),
+			ttlcache.WithCapacity[string, prometheus.Labels](uint64(p.config.LimitPerService)),
+		)
+		cache.OnEviction(
+			func(ctx context.Context, reason ttlcache.EvictionReason, item *ttlcache.Item[string, prometheus.Labels]) {
+				p.logger.Info("Evicted request context from cache",
+					zap.String("service", serviceKey),
+					zap.String("request context", item.Key()),
+				)
+
+				deletedCount := p.metrics.latencyHistogram.DeletePartialMatch(item.Value())
+
+				p.logger.Info("Deleted stale metrics",
+					zap.Int("count", deletedCount),
+					zap.Any("having label values", item.Value()),
+				)
+			},
+		)
+		p.logger.Debug("Created a cache of known request contexts for service - " + serviceKey)
+
+		go cache.Start() // starts automatic expired item deletion
+		return cache
+	})
+
+	if val := cache.Get(requestContext); cache.Len() < p.config.LimitPerService || val != nil {
+		labels := p.buildLabels(namespace, service, span, resourceSpan)
+		if val == nil {
+			// build labels map that will be used as a key to delete stale
+			// metrics when the request context cache entry is evicted
+			metricLabels := prometheus.Labels{
+				namespaceLabel: namespace,
+				serviceLabel:   service,
+				applyPromConventions(AssertsRequestContextAttribute): requestContext,
+			}
+			cache.Set(requestContext, metricLabels, ttlcache.DefaultTTL)
+			p.logger.Info("Adding request context to cache",
+				zap.String("service", serviceKey),
+				zap.String("request context", requestContext),
+			)
+		}
+		latencySeconds := computeLatency(span)
+		p.recordLatency(labels, latencySeconds)
+	} else {
+		p.logger.Warn("Too many request contexts. Metrics won't be captured for",
+			zap.String("service", serviceKey),
+			zap.String("request context", requestContext),
+		)
+	}
+}
+
+func (p *metricHelper) buildLabels(namespace string, service string, span *ptrace.Span,
+	resourceSpan *ptrace.ResourceSpans) prometheus.Labels {
+
+	p.rwMutex.RLock()
+	defer p.rwMutex.RUnlock()
+
+	labels := prometheus.Labels{
+		envLabel:       p.config.Env,
+		siteLabel:      p.config.Site,
+		namespaceLabel: namespace,
+		serviceLabel:   service,
+	}
+
+	capturedResourceAttributes := make([]string, 0)
+	capturedSpanAttributes := make([]string, 0)
+	for _, labelName := range p.getAttributesAsLabels() {
+		value, present := span.Attributes().Get(labelName)
+		if !present {
+			value, present = resourceSpan.Resource().Attributes().Get(labelName)
+			if present {
+				capturedResourceAttributes = append(capturedResourceAttributes, labelName)
+			}
+		} else {
+			capturedSpanAttributes = append(capturedSpanAttributes, labelName)
+		}
+		if present {
+			labels[applyPromConventions(labelName)] = value.AsString()
+		} else {
+			labels[applyPromConventions(labelName)] = ""
+		}
+	}
+	labels[spanKind] = span.Kind().String()
+	p.logger.Debug("Captured Metric labels",
+		zap.String("traceId", span.TraceID().String()),
+		zap.String("spanId", span.SpanID().String()),
+		zap.String("capturedSpanAttributes", strings.Join(capturedSpanAttributes, ", ")),
+		zap.String("capturedResourceAttributes", strings.Join(capturedResourceAttributes, ", ")),
+	)
+	return labels
+}
+
+func (p *metricHelper) startExporter() {
+	p.exp.start(p.metrics.prometheusRegistry)
+}
+
+func (p *metricHelper) stopExporter() error {
+	p.metrics.unregisterMetrics()
+	return p.exp.stop()
+}
+
+// configListener interface implementation
+func (p *metricHelper) isUpdated(currConfig *Config, newConfig *Config) bool {
+	p.rwMutex.RLock()
+	defer p.rwMutex.RUnlock()
+
+	updated := !reflect.DeepEqual(currConfig.CaptureAttributesInMetric, newConfig.CaptureAttributesInMetric)
+	if updated {
+		p.logger.Info("Change detected in config CaptureAttributesInMetric",
+			zap.Any("Current", currConfig.CaptureAttributesInMetric),
+			zap.Any("New", newConfig.CaptureAttributesInMetric),
+		)
+	} else {
+		p.logger.Debug("No change detected in config CaptureAttributesInMetric")
+	}
+	return updated
+}
+
+func (p *metricHelper) onUpdate(newConfig *Config) error {
+	p.rwMutex.Lock()
+	defer p.rwMutex.Unlock()
+
+	// This is a bit tricky! We cannot simply register the metric again with different labels
+	// We have to throw away the existing prometheus registry, shutdown the prometheus exporter
+	// and redo all of that work again
+	err := p.stopExporter()
+	if err == nil {
+		currConfigCaptureAttributesInMetric := p.config.CaptureAttributesInMetric
+		// use new config
+		p.config.CaptureAttributesInMetric = newConfig.CaptureAttributesInMetric
+
+		// create new prometheus registry and register metrics
+		err = p.registerMetrics()
+		if err == nil {
+			p.logger.Info("Updated config CaptureAttributesInMetric",
+				zap.Any("New", newConfig.CaptureAttributesInMetric),
+			)
+		} else {
+			p.logger.Error("Ignoring config CaptureAttributesInMetric due to error registering new latency histogram",
+				zap.Error(err),
+			)
+			// latency histogram registration failed, reverting to old config
+			// create new prometheus registry and register metrics again
+			p.config.CaptureAttributesInMetric = currConfigCaptureAttributesInMetric
+			_ = p.registerMetrics()
+		}
+
+		p.startExporter()
+	} else {
+		err = errors.New("error stopping http server exporting prometheus metrics")
+		p.logger.Error("Ignoring config CaptureAttributesInMetric", zap.Error(err))
+	}
+	return err
+}

--- a/assertsprocessor/metric_helper_test.go
+++ b/assertsprocessor/metric_helper_test.go
@@ -1,0 +1,220 @@
+package assertsprocessor
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+	"testing"
+	"time"
+)
+
+func TestBuildLabels(t *testing.T) {
+	logger, _ := zap.NewProduction()
+	attributes := []string{"rpc.system", "rpc.service", "rpc.method",
+		"aws.table.name", "aws.queue.url", "host.name"}
+	c := &Config{
+		Env:                       "dev",
+		Site:                      "us-west-2",
+		CaptureAttributesInMetric: attributes,
+	}
+	config.CaptureAttributesInMetric = attributes
+	p := newMetricHelper(
+		logger,
+		c,
+	)
+
+	resourceSpans := ptrace.NewTraces().ResourceSpans().AppendEmpty()
+	resourceSpans.Resource().Attributes().PutStr("host.name", "192.168.1.19")
+
+	testSpan := ptrace.NewSpan()
+	testSpan.SetKind(ptrace.SpanKindClient)
+	testSpan.Attributes().PutStr(AssertsRequestTypeAttribute, "outbound")
+	testSpan.Attributes().PutStr(AssertsRequestContextAttribute, "GetItem")
+	testSpan.Attributes().PutStr("rpc.system", "aws-api")
+	testSpan.Attributes().PutStr("rpc.service", "DynamoDb")
+	testSpan.Attributes().PutStr("rpc.method", "GetItem")
+	testSpan.Attributes().PutStr("aws.table.name", "ride-bookings")
+
+	expectedLabels := prometheus.Labels{}
+	expectedLabels[envLabel] = "dev"
+	expectedLabels[siteLabel] = "us-west-2"
+	expectedLabels[namespaceLabel] = "ride-services"
+	expectedLabels[serviceLabel] = "payment"
+	expectedLabels[requestContextLabel] = "GetItem"
+	expectedLabels[requestTypeLabel] = "outbound"
+	expectedLabels[errorTypeLabel] = ""
+	expectedLabels["rpc_service"] = "DynamoDb"
+	expectedLabels["rpc_method"] = "GetItem"
+	expectedLabels["aws_table_name"] = "ride-bookings"
+	expectedLabels["rpc_system"] = "aws-api"
+	expectedLabels["host_name"] = "192.168.1.19"
+	expectedLabels["span_kind"] = "Client"
+	expectedLabels["aws_queue_url"] = ""
+
+	actualLabels := p.buildLabels("ride-services", "payment", &testSpan, &resourceSpans)
+	assert.Equal(t, expectedLabels, actualLabels)
+}
+
+func TestCaptureMetrics(t *testing.T) {
+	logger, _ := zap.NewProduction()
+
+	attributes := []string{"rpc.system", "rpc.service", "rpc.method",
+		"aws.table.name", "aws.queue.url", "host.name"}
+	c := &Config{
+		Env:             "dev",
+		Site:            "us-west-2",
+		LimitPerService: 100,
+	}
+	config.CaptureAttributesInMetric = attributes
+	p := newMetricHelper(
+		logger,
+		c,
+	)
+	err := p.registerMetrics()
+	assert.Nil(t, err)
+	resourceSpans := ptrace.NewTraces().ResourceSpans().AppendEmpty()
+
+	testSpan := ptrace.NewSpan()
+	testSpan.Attributes().PutStr(AssertsRequestContextAttribute, "/request")
+	testSpan.Attributes().PutStr(AssertsRequestTypeAttribute, "inbound")
+	testSpan.Attributes().PutStr(AssertsErrorTypeAttribute, "client_errors")
+	testSpan.Attributes().PutStr("rpc.system", "aws-api")
+	testSpan.Attributes().PutStr("rpc.service", "DynamoDb")
+	testSpan.Attributes().PutStr("rpc.method", "GetItem")
+	testSpan.Attributes().PutStr("aws.table.name", "ride-bookings")
+	testSpan.Attributes().PutStr("aws.table.nameee", "ride-bookings")
+	testSpan.SetKind(ptrace.SpanKindClient)
+
+	testSpan.SetStartTimestamp(1e9)
+	testSpan.SetEndTimestamp(1e9 + 6e8)
+
+	expectedLabels := prometheus.Labels{}
+	expectedLabels[envLabel] = "dev"
+	expectedLabels[siteLabel] = "us-west-2"
+	expectedLabels[namespaceLabel] = "ride-services"
+	expectedLabels[serviceLabel] = "payment"
+	expectedLabels[requestContextLabel] = "GetItem"
+	expectedLabels["rpc_service"] = "DynamoDb"
+	expectedLabels["rpc_method"] = "GetItem"
+	expectedLabels["aws_table_name"] = "ride-bookings"
+	expectedLabels["rpc_system"] = "aws-api"
+	expectedLabels["span_kind"] = "Client"
+
+	p.captureMetrics(&testSpan, "ride-services", "payment", &resourceSpans)
+}
+
+func TestMetricCardinalityLimit(t *testing.T) {
+	logger, _ := zap.NewProduction()
+
+	c := &Config{
+		Env:             "dev",
+		Site:            "us-west-2",
+		LimitPerService: 2,
+	}
+	config.CaptureAttributesInMetric = []string{}
+	p := newMetricHelper(
+		logger,
+		c,
+	)
+	_ = p.registerMetrics()
+	resourceSpans := ptrace.NewTraces().ResourceSpans().AppendEmpty()
+
+	testSpan := ptrace.NewSpan()
+	testSpan.SetStartTimestamp(1e9)
+	testSpan.SetEndTimestamp(1e9 + 6e8)
+	testSpan.Attributes().PutStr(AssertsRequestContextAttribute, "/cart/#val1")
+	p.captureMetrics(&testSpan, "robot-shop", "cart", &resourceSpans)
+	assert.Equal(t, 1, p.requestContextsByService.Size())
+	cache, _ := p.requestContextsByService.Load("robot-shop#cart")
+	assert.Equal(t, 1, cache.Len())
+
+	testSpan.Attributes().PutStr(AssertsRequestContextAttribute, "/cart/#val2")
+	p.captureMetrics(&testSpan, "robot-shop", "cart", &resourceSpans)
+	assert.Equal(t, 2, cache.Len())
+
+	testSpan.Attributes().PutStr(AssertsRequestContextAttribute, "/cart/#val3")
+	p.captureMetrics(&testSpan, "robot-shop", "cart", &resourceSpans)
+	assert.Equal(t, 2, cache.Len())
+	assert.NotNil(t, cache.Get("/cart/#val1"))
+	assert.NotNil(t, cache.Get("/cart/#val2"))
+	assert.Nil(t, cache.Get("/cart/#val3"))
+}
+
+func TestCacheEviction(t *testing.T) {
+	logger, _ := zap.NewProduction()
+
+	c := &Config{
+		Env:                    "dev",
+		Site:                   "us-west-2",
+		LimitPerService:        2,
+		RequestContextCacheTTL: 1,
+	}
+	config.CaptureAttributesInMetric = []string{}
+	p := newMetricHelper(
+		logger,
+		c,
+	)
+	// overwrite ttl to a smaller value of 5 millis in this unit test
+	p.ttl = time.Millisecond * time.Duration(p.config.RequestContextCacheTTL)
+	_ = p.registerMetrics()
+	resourceSpans := ptrace.NewTraces().ResourceSpans().AppendEmpty()
+
+	testSpan := ptrace.NewSpan()
+	testSpan.SetStartTimestamp(1e9)
+	testSpan.SetEndTimestamp(1e9 + 6e8)
+	testSpan.Attributes().PutStr(AssertsRequestContextAttribute, "/cart/#val1")
+	p.captureMetrics(&testSpan, "robot-shop", "cart", &resourceSpans)
+	assert.Equal(t, 1, p.requestContextsByService.Size())
+	cache, _ := p.requestContextsByService.Load("robot-shop#cart")
+	assert.Equal(t, 1, cache.Len())
+	assert.Equal(t,
+		prometheus.Labels{
+			namespaceLabel: "robot-shop",
+			serviceLabel:   "cart",
+			applyPromConventions(AssertsRequestContextAttribute): "/cart/#val1",
+		},
+		cache.Get("/cart/#val1").Value())
+
+	time.Sleep(5 * time.Millisecond)
+
+	testSpan.Attributes().PutStr(AssertsRequestContextAttribute, "/cart/#val2")
+	p.captureMetrics(&testSpan, "robot-shop", "cart", &resourceSpans)
+	assert.Equal(t, 1, cache.Len())
+}
+
+func TestMetricHelperIsUpdated(t *testing.T) {
+	currConfig := &Config{
+		CaptureAttributesInMetric: []string{"rpc.system", "rpc.service"},
+	}
+	newConfig := &Config{
+		CaptureAttributesInMetric: []string{"rpc.system", "rpc.service", "rpc.method"},
+	}
+	p := newMetricHelper(
+		logger,
+		currConfig,
+	)
+
+	assert.False(t, p.isUpdated(currConfig, currConfig))
+	assert.True(t, p.isUpdated(currConfig, newConfig))
+}
+
+func TestMetricHelperOnUpdate(t *testing.T) {
+	currConfig := &Config{
+		CaptureAttributesInMetric: []string{"rpc.system", "rpc.service"},
+		PrometheusExporterPort:    9466,
+	}
+	newConfig := &Config{
+		CaptureAttributesInMetric: []string{"rpc.system", "rpc.service", "rpc.method"},
+	}
+
+	logger, _ := zap.NewProduction()
+	p := newMetricHelper(
+		logger,
+		currConfig,
+	)
+	_ = p.registerMetrics()
+	p.startExporter()
+
+	assert.Nil(t, p.onUpdate(newConfig))
+}

--- a/assertsprocessor/metrics.go
+++ b/assertsprocessor/metrics.go
@@ -1,360 +1,106 @@
 package assertsprocessor
 
 import (
-	"context"
-	"errors"
-	"github.com/jellydator/ttlcache/v3"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/collectors"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/puzpuzpuz/xsync/v2"
-	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
-	"net/http"
-	"reflect"
-	"regexp"
 	"sort"
-	"strconv"
 	"strings"
-	"sync"
-	"time"
 )
 
-const (
-	envLabel             = "asserts_env"
-	siteLabel            = "asserts_site"
-	namespaceLabel       = "namespace"
-	serviceLabel         = "service"
-	requestTypeLabel     = "asserts_request_type"
-	errorTypeLabel       = "asserts_error_type"
-	requestContextLabel  = "asserts_request_context"
-	spanKind             = "span_kind"
-	traceSampleTypeLabel = "sample_type"
-)
-
-type metricHelper struct {
+type metrics struct {
 	logger             *zap.Logger
-	config             *Config
-	httpServer         *http.Server
 	prometheusRegistry *prometheus.Registry
 	latencyHistogram   *prometheus.HistogramVec
 	totalTraceCount    *prometheus.CounterVec
 	sampledTraceCount  *prometheus.CounterVec
-	// limit cardinality of request contexts for which metrics are captured
-	requestContextsByService *xsync.MapOf[string, *ttlcache.Cache[string, prometheus.Labels]]
-	ttl                      time.Duration
-	// guard access to config.CaptureAttributesInMetric and latencyHistogram
-	rwMutex *sync.RWMutex
+	totalSpansCount    *prometheus.CounterVec
+	sampledSpansCount  *prometheus.CounterVec
 }
 
-func newMetricHelper(logger *zap.Logger, config *Config) *metricHelper {
-	return &metricHelper{
-		logger:                   logger,
-		config:                   config,
-		ttl:                      time.Minute * time.Duration(config.RequestContextCacheTTL),
-		prometheusRegistry:       prometheus.NewRegistry(),
-		requestContextsByService: xsync.NewMapOf[*ttlcache.Cache[string, prometheus.Labels]](),
-		rwMutex:                  &sync.RWMutex{},
-	}
-}
+func (m *metrics) registerMetrics(captureAttributesInMetric []string) error {
+	// Start the prometheus server on port 9465
+	m.prometheusRegistry = prometheus.NewRegistry()
 
-func (p *metricHelper) recordLatency(labels prometheus.Labels, latencySeconds float64) {
-	p.rwMutex.RLock()
-	defer p.rwMutex.RUnlock()
-	p.latencyHistogram.With(labels).Observe(latencySeconds)
-}
-
-func (p *metricHelper) registerMetrics() error {
 	var traceCountLabels = []string{envLabel, siteLabel, namespaceLabel, serviceLabel}
 	var sampledTraceCountLabels = []string{envLabel, siteLabel, namespaceLabel, traceSampleTypeLabel, serviceLabel}
-
-	p.logger.Info("Total Trace Counter with ", zap.String("labels", strings.Join(traceCountLabels, ", ")))
-	p.logger.Info("Sampled Trace Counter with ", zap.String("labels", strings.Join(sampledTraceCountLabels, ", ")))
-
-	// Start the prometheus server on port 9465
-	p.prometheusRegistry = prometheus.NewRegistry()
+	var spanCountLabels = []string{envLabel, siteLabel}
+	var err error
 
 	// Create Counter for total trace count
-	p.totalTraceCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "asserts",
-		Subsystem: "trace",
-		Name:      "count_total",
-	}, traceCountLabels)
-	err := p.prometheusRegistry.Register(p.totalTraceCount)
+	m.totalTraceCount, err = m.register("trace", "count_total", traceCountLabels, "Total Trace Counter")
 	if err != nil {
-		p.logger.Fatal("Error registering Total Trace Counter Vector", zap.Error(err))
 		return err
 	}
-
 	// Create Counter for sampled trace count
-	p.sampledTraceCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "asserts",
-		Subsystem: "trace",
-		Name:      "sampled_count_total",
-	}, sampledTraceCountLabels)
-	err = p.prometheusRegistry.Register(p.sampledTraceCount)
+	m.sampledTraceCount, err = m.register("trace", "sampled_count_total", sampledTraceCountLabels, "Sampled Trace Counter")
 	if err != nil {
-		p.logger.Fatal("Error registering Sampled Trace Counter Vector", zap.Error(err))
+		return err
+	}
+	// Create Counter for total spans count
+	m.totalSpansCount, err = m.register("spans", "count_total", spanCountLabels, "Total Spans Counter")
+	if err != nil {
+		return err
+	}
+	// Create Counter for sampled spans count
+	m.sampledSpansCount, err = m.register("spans", "sampled_count_total", spanCountLabels, "Total Spans Counter")
+	if err != nil {
 		return err
 	}
 
-	return p.registerLatencyHistogram(p.getAttributesAsLabels())
+	return m.registerLatencyHistogram(captureAttributesInMetric)
 }
 
-func (p *metricHelper) getAttributesAsLabels() []string {
-	attributes := make([]string, 0)
-	for _, att := range p.config.CaptureAttributesInMetric {
-		attributes = append(attributes, att)
+func (m *metrics) register(subsystem string, name string, labels []string, msg string) (*prometheus.CounterVec, error) {
+	m.logger.Info(msg+" with ", zap.String("labels", strings.Join(labels, ", ")))
+
+	counter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "asserts",
+		Subsystem: subsystem,
+		Name:      name,
+	}, labels)
+	err := m.prometheusRegistry.Register(counter)
+	if err != nil {
+		m.logger.Fatal("Error registering "+msg+" Vector", zap.Error(err))
+		return nil, err
 	}
-	attributes = append(attributes, AssertsRequestTypeAttribute)
-	attributes = append(attributes, AssertsRequestContextAttribute)
-	attributes = append(attributes, AssertsErrorTypeAttribute)
-	return attributes
+	return counter, nil
 }
 
-func (p *metricHelper) registerLatencyHistogram(captureAttributesInMetric []string) error {
+func (m *metrics) registerLatencyHistogram(captureAttributesInMetric []string) error {
 	var spanMetricLabels = []string{envLabel, siteLabel, namespaceLabel, serviceLabel, spanKind}
 
 	if captureAttributesInMetric != nil {
 		for _, label := range captureAttributesInMetric {
-			spanMetricLabels = append(spanMetricLabels, p.applyPromConventions(label))
+			spanMetricLabels = append(spanMetricLabels, applyPromConventions(label))
 		}
 	}
 	sort.Strings(spanMetricLabels)
-	p.logger.Info("Registering Latency Histogram with ", zap.String("labels", strings.Join(spanMetricLabels, ", ")))
+	m.logger.Info("Registering Latency Histogram with ", zap.String("labels", strings.Join(spanMetricLabels, ", ")))
 
-	p.latencyHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	m.latencyHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "otel",
 		Subsystem: "span",
 		Name:      "latency_seconds",
 	}, spanMetricLabels)
-	err := p.prometheusRegistry.Register(p.latencyHistogram)
+	err := m.prometheusRegistry.Register(m.latencyHistogram)
 	if err != nil {
-		p.logger.Fatal("Error registering Latency Histogram Metric Vector", zap.Error(err))
+		m.logger.Fatal("Error registering Latency Histogram Metric Vector", zap.Error(err))
 		return err
 	}
 
 	return nil
 }
 
-func (p *metricHelper) captureMetrics(span *ptrace.Span, namespace string, service string,
-	resourceSpan *ptrace.ResourceSpans) {
-	serviceKey := getServiceKey(namespace, service)
-	attrValue, _ := span.Attributes().Get(AssertsRequestContextAttribute)
-	requestContext := attrValue.AsString()
+func (m *metrics) unregisterMetrics() {
+	m.latencyHistogram.Reset()
+	m.totalTraceCount.Reset()
+	m.sampledTraceCount.Reset()
+	m.totalSpansCount.Reset()
+	m.sampledSpansCount.Reset()
 
-	cache, _ := p.requestContextsByService.LoadOrCompute(serviceKey, func() *ttlcache.Cache[string, prometheus.Labels] {
-		cache := ttlcache.New[string, prometheus.Labels](
-			ttlcache.WithTTL[string, prometheus.Labels](p.ttl),
-			ttlcache.WithCapacity[string, prometheus.Labels](uint64(p.config.LimitPerService)),
-		)
-		cache.OnEviction(
-			func(ctx context.Context, reason ttlcache.EvictionReason, item *ttlcache.Item[string, prometheus.Labels]) {
-				p.logger.Info("Evicted request context from cache",
-					zap.String("service", serviceKey),
-					zap.String("request context", item.Key()),
-				)
-
-				deletedCount := p.latencyHistogram.DeletePartialMatch(item.Value())
-
-				p.logger.Info("Deleted stale metrics",
-					zap.Int("count", deletedCount),
-					zap.Any("having label values", item.Value()),
-				)
-			},
-		)
-		p.logger.Debug("Created a cache of known request contexts for service - " + serviceKey)
-
-		go cache.Start() // starts automatic expired item deletion
-		return cache
-	})
-
-	if val := cache.Get(requestContext); cache.Len() < p.config.LimitPerService || val != nil {
-		labels := p.buildLabels(namespace, service, span, resourceSpan)
-		if val == nil {
-			// build labels map that will be used as a key to delete stale
-			// metrics when the request context cache entry is evicted
-			metricLabels := prometheus.Labels{
-				namespaceLabel: namespace,
-				serviceLabel:   service,
-				p.applyPromConventions(AssertsRequestContextAttribute): requestContext,
-			}
-			cache.Set(requestContext, metricLabels, ttlcache.DefaultTTL)
-			p.logger.Info("Adding request context to cache",
-				zap.String("service", serviceKey),
-				zap.String("request context", requestContext),
-			)
-		}
-		latencySeconds := computeLatency(span)
-		p.recordLatency(labels, latencySeconds)
-	} else {
-		p.logger.Warn("Too many request contexts. Metrics won't be captured for",
-			zap.String("service", serviceKey),
-			zap.String("request context", requestContext),
-		)
-	}
-}
-
-func (p *metricHelper) buildLabels(namespace string, service string, span *ptrace.Span,
-	resourceSpan *ptrace.ResourceSpans) prometheus.Labels {
-
-	p.rwMutex.RLock()
-	defer p.rwMutex.RUnlock()
-
-	labels := prometheus.Labels{
-		envLabel:       p.config.Env,
-		siteLabel:      p.config.Site,
-		namespaceLabel: namespace,
-		serviceLabel:   service,
-	}
-
-	capturedResourceAttributes := make([]string, 0)
-	capturedSpanAttributes := make([]string, 0)
-	for _, labelName := range p.getAttributesAsLabels() {
-		value, present := span.Attributes().Get(labelName)
-		if !present {
-			value, present = resourceSpan.Resource().Attributes().Get(labelName)
-			if present {
-				capturedResourceAttributes = append(capturedResourceAttributes, labelName)
-			}
-		} else {
-			capturedSpanAttributes = append(capturedSpanAttributes, labelName)
-		}
-		if present {
-			labels[p.applyPromConventions(labelName)] = value.AsString()
-		} else {
-			labels[p.applyPromConventions(labelName)] = ""
-		}
-	}
-	labels[spanKind] = span.Kind().String()
-	p.logger.Debug("Captured Metric labels",
-		zap.String("traceId", span.TraceID().String()),
-		zap.String("spanId", span.SpanID().String()),
-		zap.String("capturedSpanAttributes", strings.Join(capturedSpanAttributes, ", ")),
-		zap.String("capturedResourceAttributes", strings.Join(capturedResourceAttributes, ", ")),
-	)
-	return labels
-}
-
-func (p *metricHelper) startExporter() {
-	// Create a new ServeMux instead of using the DefaultServeMux. This allows registering
-	// a handler function for the same URL pattern again on a different htp server instance
-	sm := http.NewServeMux()
-	// Expose the registered metrics via HTTP.
-	sm.Handle("/metrics", promhttp.HandlerFor(
-		p.prometheusRegistry,
-		promhttp.HandlerOpts{},
-	))
-
-	p.httpServer = &http.Server{
-		Handler:        sm,
-		Addr:           ":" + strconv.FormatUint(p.config.PrometheusExporterPort, 10),
-		ReadTimeout:    30 * time.Second,
-		WriteTimeout:   30 * time.Second,
-		MaxHeaderBytes: 1 << 20,
-	}
-
-	// Add Go module build info.
-	p.prometheusRegistry.MustRegister(collectors.NewBuildInfoCollector())
-	p.prometheusRegistry.MustRegister(collectors.NewGoCollector(
-		collectors.WithGoCollectorRuntimeMetrics(collectors.GoRuntimeMetricsRule{Matcher: regexp.MustCompile("/.*")}),
-	))
-
-	p.logger.Info("Starting Prometheus Exporter Listening", zap.Uint64("port", p.config.PrometheusExporterPort))
-	go func() {
-		if err := p.httpServer.ListenAndServe(); err != nil {
-			if errors.Is(err, http.ErrServerClosed) {
-				p.logger.Error("Prometheus Exporter is shutdown", zap.Error(err))
-			} else if err != nil {
-				p.logger.Fatal("Error starting Prometheus Exporter", zap.Error(err))
-			}
-		}
-	}()
-}
-
-func (p *metricHelper) stopExporter() error {
-	p.latencyHistogram.Reset()
-	p.totalTraceCount.Reset()
-	p.sampledTraceCount.Reset()
-
-	p.prometheusRegistry.Unregister(p.latencyHistogram)
-	p.prometheusRegistry.Unregister(p.totalTraceCount)
-	p.prometheusRegistry.Unregister(p.sampledTraceCount)
-
-	shutdownCtx := context.Background()
-	return p.httpServer.Shutdown(shutdownCtx)
-}
-
-func (p *metricHelper) applyPromConventions(text string) string {
-	replacer := strings.NewReplacer(
-		" ", "_",
-		",", "_",
-		"\t", "_",
-		"/", "_",
-		"\\", "_",
-		".", "_",
-		"-", "_",
-		":", "_",
-		"=", "_",
-		"“", "_",
-		"@", "_",
-		"<", "_",
-		">", "_",
-		"%", "_percent",
-	)
-	return strings.ToLower(replacer.Replace(text))
-}
-
-// configListener interface implementation
-func (p *metricHelper) isUpdated(currConfig *Config, newConfig *Config) bool {
-	p.rwMutex.RLock()
-	defer p.rwMutex.RUnlock()
-
-	updated := !reflect.DeepEqual(currConfig.CaptureAttributesInMetric, newConfig.CaptureAttributesInMetric)
-	if updated {
-		p.logger.Info("Change detected in config CaptureAttributesInMetric",
-			zap.Any("Current", currConfig.CaptureAttributesInMetric),
-			zap.Any("New", newConfig.CaptureAttributesInMetric),
-		)
-	} else {
-		p.logger.Debug("No change detected in config CaptureAttributesInMetric")
-	}
-	return updated
-}
-
-func (p *metricHelper) onUpdate(newConfig *Config) error {
-	p.rwMutex.Lock()
-	defer p.rwMutex.Unlock()
-
-	// This is a bit tricky! We cannot simply register the metric again with different labels
-	// We have to throw away the existing prometheus registry, shutdown the prometheus exporter
-	// and redo all of that work again
-	err := p.stopExporter()
-	if err == nil {
-		currConfigCaptureAttributesInMetric := p.config.CaptureAttributesInMetric
-		// use new config
-		p.config.CaptureAttributesInMetric = newConfig.CaptureAttributesInMetric
-
-		// create new prometheus registry and register metrics
-		err = p.registerMetrics()
-		if err == nil {
-			p.logger.Info("Updated config CaptureAttributesInMetric",
-				zap.Any("New", newConfig.CaptureAttributesInMetric),
-			)
-		} else {
-			p.logger.Error("Ignoring config CaptureAttributesInMetric due to error registering new latency histogram",
-				zap.Error(err),
-			)
-			// latency histogram registration failed, reverting to old config
-			// create new prometheus registry and register metrics again
-			p.config.CaptureAttributesInMetric = currConfigCaptureAttributesInMetric
-			_ = p.registerMetrics()
-		}
-
-		p.startExporter()
-	} else {
-		err = errors.New("error stopping http server exporting prometheus metrics")
-		p.logger.Error("Ignoring config CaptureAttributesInMetric", zap.Error(err))
-	}
-	return err
+	m.prometheusRegistry.Unregister(m.latencyHistogram)
+	m.prometheusRegistry.Unregister(m.totalTraceCount)
+	m.prometheusRegistry.Unregister(m.sampledTraceCount)
+	m.prometheusRegistry.Unregister(m.totalSpansCount)
+	m.prometheusRegistry.Unregister(m.sampledSpansCount)
 }

--- a/assertsprocessor/metrics_exporter.go
+++ b/assertsprocessor/metrics_exporter.go
@@ -1,0 +1,61 @@
+package assertsprocessor
+
+import (
+	"context"
+	"errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.uber.org/zap"
+	"net/http"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+type metricsExporter struct {
+	logger     *zap.Logger
+	config     *Config
+	httpServer *http.Server
+}
+
+func (exp *metricsExporter) start(reg *prometheus.Registry) {
+	// Create a new ServeMux instead of using the DefaultServeMux. This allows registering
+	// a handler function for the same URL pattern again on a different htp server instance
+	sm := http.NewServeMux()
+	// Expose the registered metrics via HTTP.
+	sm.Handle("/metrics", promhttp.HandlerFor(
+		reg,
+		promhttp.HandlerOpts{},
+	))
+
+	exp.httpServer = &http.Server{
+		Handler:        sm,
+		Addr:           ":" + strconv.FormatUint(exp.config.PrometheusExporterPort, 10),
+		ReadTimeout:    30 * time.Second,
+		WriteTimeout:   30 * time.Second,
+		MaxHeaderBytes: 1 << 20,
+	}
+
+	// Add Go module build info.
+	reg.MustRegister(collectors.NewBuildInfoCollector())
+	reg.MustRegister(collectors.NewGoCollector(
+		collectors.WithGoCollectorRuntimeMetrics(collectors.GoRuntimeMetricsRule{Matcher: regexp.MustCompile("/.*")}),
+	))
+
+	exp.logger.Info("Starting Prometheus Exporter Listening", zap.Uint64("port", exp.config.PrometheusExporterPort))
+	go func() {
+		if err := exp.httpServer.ListenAndServe(); err != nil {
+			if errors.Is(err, http.ErrServerClosed) {
+				exp.logger.Error("Prometheus Exporter is shutdown", zap.Error(err))
+			} else if err != nil {
+				exp.logger.Fatal("Error starting Prometheus Exporter", zap.Error(err))
+			}
+		}
+	}()
+}
+
+func (exp *metricsExporter) stop() error {
+	shutdownCtx := context.Background()
+	return exp.httpServer.Shutdown(shutdownCtx)
+}

--- a/assertsprocessor/metrics_exporter_test.go
+++ b/assertsprocessor/metrics_exporter_test.go
@@ -1,0 +1,19 @@
+package assertsprocessor
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"testing"
+)
+
+func TestStopExporter(t *testing.T) {
+	logger, _ := zap.NewProduction()
+	exp := &metricsExporter{
+		logger: logger,
+		config: &testConfig,
+	}
+
+	exp.start(prometheus.NewRegistry())
+	assert.Nil(t, exp.stop())
+}

--- a/assertsprocessor/metrics_test.go
+++ b/assertsprocessor/metrics_test.go
@@ -3,238 +3,35 @@ package assertsprocessor
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
-	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
 	"testing"
-	"time"
 )
 
 func TestRegisterMetrics(t *testing.T) {
 	logger, _ := zap.NewProduction()
+	reg := &metrics{
+		logger:             logger,
+		prometheusRegistry: prometheus.NewRegistry(),
+	}
 	attributes := []string{"rpc.system", "rpc.service", "rpc.method",
 		"aws.table.name", "aws.queue.url", "host.name"}
-	c := &Config{
-		Env:  "dev",
-		Site: "us-west-2",
-	}
-	config.CaptureAttributesInMetric = attributes
-	p := newMetricHelper(
-		logger,
-		c,
-	)
-	assert.Nil(t, p.registerMetrics())
-	assert.NotNil(t, p.prometheusRegistry)
-	assert.NotNil(t, p.latencyHistogram)
-	assert.NotNil(t, p.sampledTraceCount)
-	assert.NotNil(t, p.totalTraceCount)
+
+	assert.Nil(t, reg.registerMetrics(attributes))
+	assert.NotNil(t, reg.prometheusRegistry)
+	assert.NotNil(t, reg.latencyHistogram)
+	assert.NotNil(t, reg.sampledTraceCount)
+	assert.NotNil(t, reg.totalTraceCount)
 }
 
-func TestBuildLabels(t *testing.T) {
+func TestUnregisterMetrics(t *testing.T) {
 	logger, _ := zap.NewProduction()
+	reg := &metrics{
+		logger:             logger,
+		prometheusRegistry: prometheus.NewRegistry(),
+	}
 	attributes := []string{"rpc.system", "rpc.service", "rpc.method",
 		"aws.table.name", "aws.queue.url", "host.name"}
-	c := &Config{
-		Env:                       "dev",
-		Site:                      "us-west-2",
-		CaptureAttributesInMetric: attributes,
-	}
-	config.CaptureAttributesInMetric = attributes
-	p := newMetricHelper(
-		logger,
-		c,
-	)
 
-	resourceSpans := ptrace.NewTraces().ResourceSpans().AppendEmpty()
-	resourceSpans.Resource().Attributes().PutStr("host.name", "192.168.1.19")
-
-	testSpan := ptrace.NewSpan()
-	testSpan.SetKind(ptrace.SpanKindClient)
-	testSpan.Attributes().PutStr(AssertsRequestTypeAttribute, "outbound")
-	testSpan.Attributes().PutStr(AssertsRequestContextAttribute, "GetItem")
-	testSpan.Attributes().PutStr("rpc.system", "aws-api")
-	testSpan.Attributes().PutStr("rpc.service", "DynamoDb")
-	testSpan.Attributes().PutStr("rpc.method", "GetItem")
-	testSpan.Attributes().PutStr("aws.table.name", "ride-bookings")
-
-	expectedLabels := prometheus.Labels{}
-	expectedLabels[envLabel] = "dev"
-	expectedLabels[siteLabel] = "us-west-2"
-	expectedLabels[namespaceLabel] = "ride-services"
-	expectedLabels[serviceLabel] = "payment"
-	expectedLabels[requestContextLabel] = "GetItem"
-	expectedLabels[requestTypeLabel] = "outbound"
-	expectedLabels[errorTypeLabel] = ""
-	expectedLabels["rpc_service"] = "DynamoDb"
-	expectedLabels["rpc_method"] = "GetItem"
-	expectedLabels["aws_table_name"] = "ride-bookings"
-	expectedLabels["rpc_system"] = "aws-api"
-	expectedLabels["host_name"] = "192.168.1.19"
-	expectedLabels["span_kind"] = "Client"
-	expectedLabels["aws_queue_url"] = ""
-
-	actualLabels := p.buildLabels("ride-services", "payment", &testSpan, &resourceSpans)
-	assert.Equal(t, expectedLabels, actualLabels)
-}
-
-func TestCaptureMetrics(t *testing.T) {
-	logger, _ := zap.NewProduction()
-
-	attributes := []string{"rpc.system", "rpc.service", "rpc.method",
-		"aws.table.name", "aws.queue.url", "host.name"}
-	c := &Config{
-		Env:             "dev",
-		Site:            "us-west-2",
-		LimitPerService: 100,
-	}
-	config.CaptureAttributesInMetric = attributes
-	p := newMetricHelper(
-		logger,
-		c,
-	)
-	err := p.registerMetrics()
-	assert.Nil(t, err)
-	resourceSpans := ptrace.NewTraces().ResourceSpans().AppendEmpty()
-
-	testSpan := ptrace.NewSpan()
-	testSpan.Attributes().PutStr(AssertsRequestContextAttribute, "/request")
-	testSpan.Attributes().PutStr(AssertsRequestTypeAttribute, "inbound")
-	testSpan.Attributes().PutStr(AssertsErrorTypeAttribute, "client_errors")
-	testSpan.Attributes().PutStr("rpc.system", "aws-api")
-	testSpan.Attributes().PutStr("rpc.service", "DynamoDb")
-	testSpan.Attributes().PutStr("rpc.method", "GetItem")
-	testSpan.Attributes().PutStr("aws.table.name", "ride-bookings")
-	testSpan.Attributes().PutStr("aws.table.nameee", "ride-bookings")
-	testSpan.SetKind(ptrace.SpanKindClient)
-
-	testSpan.SetStartTimestamp(1e9)
-	testSpan.SetEndTimestamp(1e9 + 6e8)
-
-	expectedLabels := prometheus.Labels{}
-	expectedLabels[envLabel] = "dev"
-	expectedLabels[siteLabel] = "us-west-2"
-	expectedLabels[namespaceLabel] = "ride-services"
-	expectedLabels[serviceLabel] = "payment"
-	expectedLabels[requestContextLabel] = "GetItem"
-	expectedLabels["rpc_service"] = "DynamoDb"
-	expectedLabels["rpc_method"] = "GetItem"
-	expectedLabels["aws_table_name"] = "ride-bookings"
-	expectedLabels["rpc_system"] = "aws-api"
-	expectedLabels["span_kind"] = "Client"
-
-	p.captureMetrics(&testSpan, "ride-services", "payment", &resourceSpans)
-}
-
-func TestMetricCardinalityLimit(t *testing.T) {
-	logger, _ := zap.NewProduction()
-
-	c := &Config{
-		Env:             "dev",
-		Site:            "us-west-2",
-		LimitPerService: 2,
-	}
-	config.CaptureAttributesInMetric = []string{}
-	p := newMetricHelper(
-		logger,
-		c,
-	)
-	_ = p.registerMetrics()
-	resourceSpans := ptrace.NewTraces().ResourceSpans().AppendEmpty()
-
-	testSpan := ptrace.NewSpan()
-	testSpan.SetStartTimestamp(1e9)
-	testSpan.SetEndTimestamp(1e9 + 6e8)
-	testSpan.Attributes().PutStr(AssertsRequestContextAttribute, "/cart/#val1")
-	p.captureMetrics(&testSpan, "robot-shop", "cart", &resourceSpans)
-	assert.Equal(t, 1, p.requestContextsByService.Size())
-	cache, _ := p.requestContextsByService.Load("robot-shop#cart")
-	assert.Equal(t, 1, cache.Len())
-
-	testSpan.Attributes().PutStr(AssertsRequestContextAttribute, "/cart/#val2")
-	p.captureMetrics(&testSpan, "robot-shop", "cart", &resourceSpans)
-	assert.Equal(t, 2, cache.Len())
-
-	testSpan.Attributes().PutStr(AssertsRequestContextAttribute, "/cart/#val3")
-	p.captureMetrics(&testSpan, "robot-shop", "cart", &resourceSpans)
-	assert.Equal(t, 2, cache.Len())
-	assert.NotNil(t, cache.Get("/cart/#val1"))
-	assert.NotNil(t, cache.Get("/cart/#val2"))
-	assert.Nil(t, cache.Get("/cart/#val3"))
-}
-
-func TestCacheEviction(t *testing.T) {
-	logger, _ := zap.NewProduction()
-
-	c := &Config{
-		Env:                    "dev",
-		Site:                   "us-west-2",
-		LimitPerService:        2,
-		RequestContextCacheTTL: 1,
-	}
-	config.CaptureAttributesInMetric = []string{}
-	p := newMetricHelper(
-		logger,
-		c,
-	)
-	// overwrite ttl to a smaller value of 5 millis in this unit test
-	p.ttl = time.Millisecond * time.Duration(p.config.RequestContextCacheTTL)
-	_ = p.registerMetrics()
-	resourceSpans := ptrace.NewTraces().ResourceSpans().AppendEmpty()
-
-	testSpan := ptrace.NewSpan()
-	testSpan.SetStartTimestamp(1e9)
-	testSpan.SetEndTimestamp(1e9 + 6e8)
-	testSpan.Attributes().PutStr(AssertsRequestContextAttribute, "/cart/#val1")
-	p.captureMetrics(&testSpan, "robot-shop", "cart", &resourceSpans)
-	assert.Equal(t, 1, p.requestContextsByService.Size())
-	cache, _ := p.requestContextsByService.Load("robot-shop#cart")
-	assert.Equal(t, 1, cache.Len())
-	assert.Equal(t,
-		prometheus.Labels{
-			namespaceLabel: "robot-shop",
-			serviceLabel:   "cart",
-			p.applyPromConventions(AssertsRequestContextAttribute): "/cart/#val1",
-		},
-		cache.Get("/cart/#val1").Value())
-
-	time.Sleep(5 * time.Millisecond)
-
-	testSpan.Attributes().PutStr(AssertsRequestContextAttribute, "/cart/#val2")
-	p.captureMetrics(&testSpan, "robot-shop", "cart", &resourceSpans)
-	assert.Equal(t, 1, cache.Len())
-}
-
-func TestMetricHelperIsUpdated(t *testing.T) {
-	currConfig := &Config{
-		CaptureAttributesInMetric: []string{"rpc.system", "rpc.service"},
-	}
-	newConfig := &Config{
-		CaptureAttributesInMetric: []string{"rpc.system", "rpc.service", "rpc.method"},
-	}
-	p := newMetricHelper(
-		logger,
-		currConfig,
-	)
-
-	assert.False(t, p.isUpdated(currConfig, currConfig))
-	assert.True(t, p.isUpdated(currConfig, newConfig))
-}
-
-func TestMetricHelperOnUpdate(t *testing.T) {
-	currConfig := &Config{
-		CaptureAttributesInMetric: []string{"rpc.system", "rpc.service"},
-		PrometheusExporterPort:    9466,
-	}
-	newConfig := &Config{
-		CaptureAttributesInMetric: []string{"rpc.system", "rpc.service", "rpc.method"},
-	}
-
-	logger, _ := zap.NewProduction()
-	p := newMetricHelper(
-		logger,
-		currConfig,
-	)
-	_ = p.registerMetrics()
-	p.startExporter()
-
-	assert.Nil(t, p.onUpdate(newConfig))
+	_ = reg.registerMetrics(attributes)
+	reg.unregisterMetrics()
 }

--- a/assertsprocessor/processor_test.go
+++ b/assertsprocessor/processor_test.go
@@ -114,7 +114,7 @@ func TestConsumeTraces(t *testing.T) {
 			stop:               make(chan bool),
 			traceFlushTicker:   clock.FromContext(ctx).NewTicker(time.Minute),
 			thresholdHelper:    &_th,
-			metricHelper:       buildMetricHelper(),
+			metrics:            buildMetrics(),
 		},
 		rwMutex: &sync.RWMutex{},
 	}

--- a/assertsprocessor/sampler_test.go
+++ b/assertsprocessor/sampler_test.go
@@ -40,7 +40,7 @@ func TestSpanIsSlowTrue(t *testing.T) {
 		logger:          logger,
 		config:          &config,
 		thresholdHelper: &th,
-		metricHelper:    buildMetricHelper(),
+		metrics:         buildMetrics(),
 	}
 
 	testSpan := ptrace.NewSpan()
@@ -60,7 +60,7 @@ func TestSpanIsSlowFalse(t *testing.T) {
 		logger:          logger,
 		config:          &config,
 		thresholdHelper: &th,
-		metricHelper:    buildMetricHelper(),
+		metrics:         buildMetrics(),
 	}
 
 	testSpan := ptrace.NewSpan()
@@ -82,7 +82,7 @@ func TestSampleTraceWithErrorSpan(t *testing.T) {
 		config:             &config,
 		thresholdHelper:    &th,
 		topTracesByService: &cache,
-		metricHelper:       buildMetricHelper(),
+		metrics:            buildMetrics(),
 	}
 
 	ctx := context.Background()
@@ -148,7 +148,7 @@ func TestSampleTraceWithSlowSpan(t *testing.T) {
 		config:             &config,
 		thresholdHelper:    &th,
 		topTracesByService: &cache,
-		metricHelper:       buildMetricHelper(),
+		metrics:            buildMetrics(),
 	}
 
 	ctx := context.Background()
@@ -215,7 +215,7 @@ func TestSampleTraceWithTwoSegments(t *testing.T) {
 		config:             &config,
 		thresholdHelper:    &th,
 		topTracesByService: &cache,
-		metricHelper:       buildMetricHelper(),
+		metrics:            buildMetrics(),
 	}
 
 	ctx := context.Background()
@@ -317,7 +317,7 @@ func TestSampleNormalTrace(t *testing.T) {
 		config:             &config,
 		thresholdHelper:    &th,
 		topTracesByService: &cache,
-		metricHelper:       buildMetricHelper(),
+		metrics:            buildMetrics(),
 	}
 
 	ctx := context.Background()
@@ -377,8 +377,10 @@ func TestSampleNormalTrace(t *testing.T) {
 
 func TestWithNoRootTrace(t *testing.T) {
 	var s = sampler{
+		logger:             logger,
+		config:             &config,
 		topTracesByService: &sync.Map{},
-		metricHelper:       buildMetricHelper(),
+		metrics:            buildMetrics(),
 	}
 	ctx := context.Background()
 	tr := newTrace(
@@ -400,7 +402,7 @@ func TestTraceCardinalityLimit(t *testing.T) {
 		config:             &config,
 		thresholdHelper:    &th,
 		topTracesByService: &cache,
-		metricHelper:       buildMetricHelper(),
+		metrics:            buildMetrics(),
 	}
 
 	ctx := context.Background()
@@ -453,7 +455,7 @@ func TestFlushTraces(t *testing.T) {
 		traceFlushTicker:   clock.FromContext(ctx).NewTicker(time.Millisecond),
 		nextConsumer:       dConsumer,
 		stop:               make(chan bool, 5),
-		metricHelper:       buildMetricHelper(),
+		metrics:            buildMetrics(),
 	}
 
 	latencyTrace := ptrace.NewTraces()
@@ -565,24 +567,30 @@ func TestFlushTraces(t *testing.T) {
 	time.Sleep(1 * time.Millisecond)
 }
 
-func buildMetricHelper() *metricHelper {
-	m := &metricHelper{
-		sampledTraceCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: "asserts",
-			Subsystem: "trace",
-			Name:      "sampled_count_total",
-		}, []string{envLabel, siteLabel, namespaceLabel, serviceLabel, traceSampleTypeLabel}),
-	}
-	m.sampledTraceCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+func buildMetrics() *metrics {
+	reg := &metrics{}
+	reg.sampledTraceCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "asserts",
 		Subsystem: "trace",
 		Name:      "sampled_count_total",
 	}, []string{envLabel, siteLabel, namespaceLabel, serviceLabel, traceSampleTypeLabel})
 
-	m.totalTraceCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+	reg.totalTraceCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "asserts",
 		Subsystem: "trace",
 		Name:      "count_total",
 	}, []string{envLabel, siteLabel, namespaceLabel, serviceLabel})
-	return m
+
+	reg.totalSpansCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "asserts",
+		Subsystem: "spans",
+		Name:      "count_total",
+	}, []string{envLabel, siteLabel})
+
+	reg.sampledSpansCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "asserts",
+		Subsystem: "spans",
+		Name:      "sampled_count_total",
+	}, []string{envLabel, siteLabel})
+	return reg
 }

--- a/assertsprocessor/trace.go
+++ b/assertsprocessor/trace.go
@@ -6,6 +6,17 @@ type trace struct {
 	segments []*traceSegment
 }
 
+func (tr *trace) getSpanCount() int {
+	var count int
+	for _, ts := range tr.segments {
+		count += len(ts.entrySpans) + len(ts.exitSpans) + len(ts.internalSpans)
+		if ts.rootSpan != nil {
+			count += 1
+		}
+	}
+	return count
+}
+
 type traceSegment struct {
 	resourceSpans    *ptrace.ResourceSpans
 	namespace        string

--- a/assertsprocessor/trace_test.go
+++ b/assertsprocessor/trace_test.go
@@ -53,3 +53,28 @@ func TestGetMainSpan(t *testing.T) {
 	assert.Equal(t, &exitSpan, ts3.getMainSpan())
 	assert.Nil(t, ts4.getMainSpan())
 }
+
+func TestGetSpanCount(t *testing.T) {
+	span := ptrace.NewSpan()
+
+	ts1 := &traceSegment{
+		rootSpan:   &span,
+		entrySpans: []*ptrace.Span{&span, &span},
+		exitSpans:  []*ptrace.Span{&span},
+	}
+	ts2 := &traceSegment{
+		entrySpans: []*ptrace.Span{&span},
+		exitSpans:  []*ptrace.Span{&span, &span},
+	}
+	ts3 := &traceSegment{
+		exitSpans:     []*ptrace.Span{&span, &span},
+		internalSpans: []*ptrace.Span{&span, &span},
+	}
+	ts4 := &traceSegment{}
+
+	tr := trace{
+		segments: []*traceSegment{ts1, ts2, ts3, ts4},
+	}
+
+	assert.Equal(t, 11, tr.getSpanCount())
+}

--- a/assertsprocessor/utils.go
+++ b/assertsprocessor/utils.go
@@ -3,6 +3,7 @@ package assertsprocessor
 import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	"strings"
 )
 
 func getServiceKey(namespace string, service string) string {
@@ -134,4 +135,24 @@ func isExitSpan(span *ptrace.Span) bool {
 
 func isRootSpan(span *ptrace.Span) bool {
 	return span.ParentSpanID().IsEmpty()
+}
+
+func applyPromConventions(text string) string {
+	replacer := strings.NewReplacer(
+		" ", "_",
+		",", "_",
+		"\t", "_",
+		"/", "_",
+		"\\", "_",
+		".", "_",
+		"-", "_",
+		":", "_",
+		"=", "_",
+		"“", "_",
+		"@", "_",
+		"<", "_",
+		">", "_",
+		"%", "_percent",
+	)
+	return strings.ToLower(replacer.Replace(text))
 }


### PR DESCRIPTION
- refactored and moved the following from metricHelper
  * renamed metrics to metrics_helper
  * metrics - register and unregister latency histogram, trace count and span count metrics
  * metrics_exporter - start / stop prometheus exporter