### PR TITLE
Split CF template by trace store backend

### DIFF
--- a/Dockerfile.all-exporters
+++ b/Dockerfile.all-exporters
@@ -1,7 +1,6 @@
-FROM amazonlinux:2
+FROM asserts/otel-collector:v0.0.81
 
 WORKDIR /opt/asserts
-COPY asserts-otel-collector /opt/asserts
 COPY start-collector.sh /opt/asserts
 
 WORKDIR /etc/asserts

--- a/deployment/ecs/otel-collector-ecs-service-aws.yaml
+++ b/deployment/ecs/otel-collector-ecs-service-aws.yaml
@@ -4,12 +4,11 @@ Parameters:
   AssertsEnvironment:
     Type: String
     Description: The installation environment name
+
   AssertsSite:
     Type: String
     Description: The installation site name
-  OTLPExportEndpoint:
-    Type: String
-    Description: OTLP Endpoint to export traces to
+
   Cluster:
     Type: String
     Description: "Asserts OTEL Cluster"
@@ -33,6 +32,11 @@ Parameters:
     Description: "Asserts OTEL Collector Image version"
     Default: docker.io/asserts/otel-collector:v0.0.78
 
+  MetricExporterVersion:
+    Type: String
+    Description: "Metric Exporter Sidecar Image version"
+    Default: docker.io/asserts/ecs-dockerstats-exporter:v1.0.0
+
   AssertsApiServerURL:
     Type: String
     Description: Asserts ApiServer Username
@@ -41,6 +45,18 @@ Parameters:
     Type: String
 
   AssertsApiServerPassword:
+    Type: String
+    NoEcho: true
+
+  AssertsRemoteWriteURL:
+    Type: String
+    Default: https://acme.tsdb.asserts.ai
+
+  AssertsTenantName:
+    Type: String
+    Default: Acme
+
+  AssertsTSDBPassword:
     Type: String
     NoEcho: true
 
@@ -151,7 +167,7 @@ Resources:
               HostPort: 4318
               Protocol: tcp
           DockerLabels:
-            PROMETHEUS_EXPORTER_PORT: 8465
+            PROMETHEUS_EXPORTER_PORT: 9465
             PROMETHEUS_EXPORTER_PATH: /metrics
           Environment:
             - Name: ASSERTS_SERVER_API_ENDPOINT
@@ -162,9 +178,41 @@ Resources:
               Value: !Ref AssertsSite
             - Name: TRACE_STORE
               Value: AWS-XRAY
-            - Name: OTLP_ENDPOINT
-              Value: !Ref OTLPExportEndpoint
             - Name: ASSERTS_SERVER_USERNAME
               Value: !Ref AssertsApiServerUsername
             - Name: ASSERTS_SERVER_PASSWORD
               Value: !Ref AssertsApiServerPassword
+            - Name: LOG_LEVEL
+              Value: !Ref LogLevel
+        - Essential: true
+          Name: metric-exporter
+          Image: !Ref MetricExporterVersion
+          LinuxParameters: { }
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Sub "asserts-otel-collector-${AssertsEnvironment}"
+              awslogs-region:
+                Ref: AWS::Region
+              awslogs-stream-prefix: metric-exporter
+          PortMappings:
+            - ContainerPort: 8429
+              HostPort: 8429
+              Protocol: tcp
+          DependsOn:
+            - Condition: START
+              ContainerName: asserts-otel-collector
+          Environment:
+            - Name: remoteWrite_basicAuth_username
+              Value: !Ref AssertsTenantName
+            - Name: httpAuth_username
+              Value: !Ref AssertsTenantName
+            - Name: remoteWrite_url
+              Value: !Ref AssertsRemoteWriteURL
+            - Name: remoteWrite_basicAuth_password
+              Value: !Ref AssertsTSDBPassword
+            - Name: httpAuth_password
+              Value: !Ref AssertsTSDBPassword
+          DockerLabels:
+            PROMETHEUS_EXPORTER_PORT: 8014
+            PROMETHEUS_EXPORTER_PATH: /container-stats/actuator/prometheus

--- a/deployment/ecs/otel-collector-ecs-service-cloudtrace.yaml
+++ b/deployment/ecs/otel-collector-ecs-service-cloudtrace.yaml
@@ -1,0 +1,216 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Asserts OTEL Collector Security Group Stack
+Parameters:
+  AssertsEnvironment:
+    Type: String
+    Description: The installation environment name
+  AssertsSite:
+    Type: String
+    Description: The installation site name
+
+  Cluster:
+    Type: String
+    Description: "Asserts OTEL Cluster"
+    Default: "asserts-otel"
+
+  ECSSubnets:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: "The IDs of the subnets on which the OTEL Collector ECS Tasks should be installed."
+
+  ECSSecurityGroupId:
+    Type: String
+
+  AssignPublicIPToECSTask:
+    Type: String
+    Description: Determines whether the ECS Task ENIs will be assigned a public IP
+    Default: "ENABLED"
+    AllowedValues: [ "ENABLED", "DISABLED" ]
+
+  AssertsOTELCollectorVersion:
+    Type: String
+    Description: "Asserts OTEL Collector Image version"
+    Default: docker.io/asserts/otel-collector:v0.0.78
+
+  MetricExporterVersion:
+    Type: String
+    Description: "Metric Exporter Sidecar Image version"
+    Default: docker.io/asserts/ecs-dockerstats-exporter:v1.0.0
+
+  AssertsApiServerURL:
+    Type: String
+    Description: Asserts ApiServer Username
+
+  AssertsApiServerUsername:
+    Type: String
+
+  AssertsApiServerPassword:
+    Type: String
+    NoEcho: true
+
+  AssertsRemoteWriteURL:
+    Type: String
+    Default: https://acme.tsdb.asserts.ai
+
+  AssertsTenantName:
+    Type: String
+    Default: Acme
+
+  AssertsTSDBPassword:
+    Type: String
+    NoEcho: true
+
+  NumCollectorInstances:
+    Type: String
+    Description: Number of Collector Instances to install
+
+  LogLevel:
+    Type: String
+    Default: info
+
+  CollectorHTTPTargetGroupARN:
+    Type: String
+Resources:
+  OTELCollectorECSCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Join [ "-", [ !Ref Cluster, !Ref AssertsEnvironment ] ]
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "Asserts OTEL Collector"
+      ClusterSettings:
+        - Name: containerInsights
+          Value: disabled
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "Asserts OTEL Collector"
+      LogGroupName: !Join ["-", ["asserts-otel-collector" , !Ref AssertsEnvironment]]
+      RetentionInDays: 7
+
+  AssertsOTELCollectorService:
+    Type: AWS::ECS::Service
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "Asserts OTEL Collector"
+      Cluster: !Join [ "-", [ !Ref Cluster, !Ref AssertsEnvironment ] ]
+      ServiceName: !Join [ "-", [ "asserts-otel-collector", !Ref AssertsEnvironment ] ]
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 100
+      DeploymentController:
+        Type: ECS
+      LaunchType: FARGATE
+      DesiredCount: !Ref NumCollectorInstances
+      LoadBalancers:
+        - ContainerName: asserts-otel-collector
+          ContainerPort: 4318
+          TargetGroupArn: !Ref CollectorHTTPTargetGroupARN
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: !Ref AssignPublicIPToECSTask
+          SecurityGroups:
+            - !Ref ECSSecurityGroupId
+          Subnets: !Ref ECSSubnets
+      PlatformVersion: 1.4.0
+      PropagateTags: SERVICE
+      SchedulingStrategy: REPLICA
+      TaskDefinition:
+        Ref: AssertsOTELCollectorTaskDefinition
+
+  AssertsOTELCollectorTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "Asserts OTEL Collector"
+      Cpu: "2048"
+      ExecutionRoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/AssertsOTELECSExecutionRole-${AssertsEnvironment}"
+      TaskRoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/AssertsOTELECSTaskRole-${AssertsEnvironment}"
+      Family: !Sub "asserts-otel-${AssertsEnvironment}"
+      Memory: "4096"
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ContainerDefinitions:
+        - Essential: true
+          Image: !Ref AssertsOTELCollectorVersion
+          Name: asserts-otel-collector
+          LinuxParameters: { }
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Sub "asserts-otel-collector-${AssertsEnvironment}"
+              awslogs-region:
+                Ref: AWS::Region
+              awslogs-stream-prefix: asserts-otel-collector
+          PortMappings:
+            - ContainerPort: 4317
+              HostPort: 4317
+              Protocol: tcp
+            - ContainerPort: 4318
+              HostPort: 4318
+              Protocol: tcp
+          DockerLabels:
+            PROMETHEUS_EXPORTER_PORT: 9465
+            PROMETHEUS_EXPORTER_PATH: /metrics
+          Environment:
+            - Name: ASSERTS_SERVER_API_ENDPOINT
+              Value: !Ref AssertsApiServerURL
+            - Name: ASSERTS_ENV
+              Value: !Ref AssertsEnvironment
+            - Name: ASSERTS_SITE
+              Value: !Ref AssertsSite
+            - Name: TRACE_STORE
+              Value: GOOGLE-CLOUDTRACE
+            - Name: GCP_PROJECT_NAME
+              Value: !Ref GCPProjectName
+            - Name: ASSERTS_SERVER_USERNAME
+              Value: !Ref AssertsApiServerUsername
+            - Name: ASSERTS_SERVER_PASSWORD
+              Value: !Ref AssertsApiServerPassword
+            - Name: LOG_LEVEL
+              Value: !Ref LogLevel
+        - Essential: true
+          Name: metric-exporter
+          Image: !Ref MetricExporterVersion
+          LinuxParameters: { }
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Sub "asserts-otel-collector-${AssertsEnvironment}"
+              awslogs-region:
+                Ref: AWS::Region
+              awslogs-stream-prefix: metric-exporter
+          PortMappings:
+            - ContainerPort: 8429
+              HostPort: 8429
+              Protocol: tcp
+          DependsOn:
+            - Condition: START
+              ContainerName: asserts-otel-collector
+          Environment:
+            - Name: remoteWrite_basicAuth_username
+              Value: !Ref AssertsTenantName
+            - Name: httpAuth_username
+              Value: !Ref AssertsTenantName
+            - Name: remoteWrite_url
+              Value: !Ref AssertsRemoteWriteURL
+            - Name: remoteWrite_basicAuth_password
+              Value: !Ref AssertsTSDBPassword
+            - Name: httpAuth_password
+              Value: !Ref AssertsTSDBPassword
+          DockerLabels:
+            PROMETHEUS_EXPORTER_PORT: 8014
+            PROMETHEUS_EXPORTER_PATH: /container-stats/actuator/prometheus

--- a/deployment/ecs/otel-collector-ecs-service-otlp.yaml
+++ b/deployment/ecs/otel-collector-ecs-service-otlp.yaml
@@ -1,0 +1,225 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Asserts OTEL Collector Security Group Stack
+Parameters:
+  AssertsEnvironment:
+    Type: String
+    Description: The installation environment name
+  AssertsSite:
+    Type: String
+    Description: The installation site name
+  OTLPExportEndpoint:
+    Type: String
+    Description: OTLP Endpoint to export traces to
+  Cluster:
+    Type: String
+    Description: "Asserts OTEL Cluster"
+    Default: "asserts-otel"
+
+  ECSSubnets:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: "The IDs of the subnets on which the OTEL Collector ECS Tasks should be installed."
+
+  ECSSecurityGroupId:
+    Type: String
+
+  AssignPublicIPToECSTask:
+    Type: String
+    Description: Determines whether the ECS Task ENIs will be assigned a public IP
+    Default: "ENABLED"
+    AllowedValues: [ "ENABLED", "DISABLED" ]
+
+  AssertsOTELCollectorVersion:
+    Type: String
+    Description: "Asserts OTEL Collector Image version"
+    Default: docker.io/asserts/otel-collector:v0.0.78
+
+  TraceStore:
+    Type: String
+    Description: Backend trace store. One of OTLP, OTLP-HTTP
+    AllowedValues:
+      - OTLP
+      - OTLP-HTTP
+
+  MetricExporterVersion:
+    Type: String
+    Description: "Metric Exporter Sidecar Image version"
+    Default: docker.io/asserts/ecs-dockerstats-exporter:v1.0.0
+
+  AssertsApiServerURL:
+    Type: String
+    Description: Asserts ApiServer Username
+
+  AssertsApiServerUsername:
+    Type: String
+
+  AssertsApiServerPassword:
+    Type: String
+    NoEcho: true
+
+  AssertsRemoteWriteURL:
+    Type: String
+    Default: https://acme.tsdb.asserts.ai
+
+  AssertsTenantName:
+    Type: String
+    Default: Acme
+
+  AssertsTSDBPassword:
+    Type: String
+    NoEcho: true
+
+  NumCollectorInstances:
+    Type: String
+    Description: Number of Collector Instances to install
+
+  LogLevel:
+    Type: String
+    Default: info
+
+  CollectorHTTPTargetGroupARN:
+    Type: String
+Resources:
+  OTELCollectorECSCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Join [ "-", [ !Ref Cluster, !Ref AssertsEnvironment ] ]
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "Asserts OTEL Collector"
+      ClusterSettings:
+        - Name: containerInsights
+          Value: disabled
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "Asserts OTEL Collector"
+      LogGroupName: !Join ["-", ["asserts-otel-collector" , !Ref AssertsEnvironment]]
+      RetentionInDays: 7
+
+  AssertsOTELCollectorService:
+    Type: AWS::ECS::Service
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "Asserts OTEL Collector"
+      Cluster: !Join [ "-", [ !Ref Cluster, !Ref AssertsEnvironment ] ]
+      ServiceName: !Join [ "-", [ "asserts-otel-collector", !Ref AssertsEnvironment ] ]
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 100
+      DeploymentController:
+        Type: ECS
+      LaunchType: FARGATE
+      DesiredCount: !Ref NumCollectorInstances
+      LoadBalancers:
+        - ContainerName: asserts-otel-collector
+          ContainerPort: 4318
+          TargetGroupArn: !Ref CollectorHTTPTargetGroupARN
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: !Ref AssignPublicIPToECSTask
+          SecurityGroups:
+            - !Ref ECSSecurityGroupId
+          Subnets: !Ref ECSSubnets
+      PlatformVersion: 1.4.0
+      PropagateTags: SERVICE
+      SchedulingStrategy: REPLICA
+      TaskDefinition:
+        Ref: AssertsOTELCollectorTaskDefinition
+
+  AssertsOTELCollectorTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "Asserts OTEL Collector"
+      Cpu: "2048"
+      ExecutionRoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/AssertsOTELECSExecutionRole-${AssertsEnvironment}"
+      TaskRoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/AssertsOTELECSTaskRole-${AssertsEnvironment}"
+      Family: !Sub "asserts-otel-${AssertsEnvironment}"
+      Memory: "4096"
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ContainerDefinitions:
+        - Essential: true
+          Image: !Ref AssertsOTELCollectorVersion
+          Name: asserts-otel-collector
+          LinuxParameters: { }
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Sub "asserts-otel-collector-${AssertsEnvironment}"
+              awslogs-region:
+                Ref: AWS::Region
+              awslogs-stream-prefix: asserts-otel-collector
+          PortMappings:
+            - ContainerPort: 4317
+              HostPort: 4317
+              Protocol: tcp
+            - ContainerPort: 4318
+              HostPort: 4318
+              Protocol: tcp
+          DockerLabels:
+            PROMETHEUS_EXPORTER_PORT: 9465
+            PROMETHEUS_EXPORTER_PATH: /metrics
+          Environment:
+            - Name: ASSERTS_SERVER_API_ENDPOINT
+              Value: !Ref AssertsApiServerURL
+            - Name: ASSERTS_ENV
+              Value: !Ref AssertsEnvironment
+            - Name: ASSERTS_SITE
+              Value: !Ref AssertsSite
+            - Name: TRACE_STORE
+              Value: !Ref TraceStore
+            - Name: OTLP_ENDPOINT
+              Value: !Ref OTLPExportEndpoint
+            - Name: ASSERTS_SERVER_USERNAME
+              Value: !Ref AssertsApiServerUsername
+            - Name: ASSERTS_SERVER_PASSWORD
+              Value: !Ref AssertsApiServerPassword
+            - Name: LOG_LEVEL
+              Value: !Ref LogLevel
+        - Essential: true
+          Name: metric-exporter
+          Image: !Ref MetricExporterVersion
+          LinuxParameters: { }
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Sub "asserts-otel-collector-${AssertsEnvironment}"
+              awslogs-region:
+                Ref: AWS::Region
+              awslogs-stream-prefix: metric-exporter
+          PortMappings:
+            - ContainerPort: 8429
+              HostPort: 8429
+              Protocol: tcp
+          DependsOn:
+            - Condition: START
+              ContainerName: asserts-otel-collector
+          Environment:
+            - Name: remoteWrite_basicAuth_username
+              Value: !Ref AssertsTenantName
+            - Name: httpAuth_username
+              Value: !Ref AssertsTenantName
+            - Name: remoteWrite_url
+              Value: !Ref AssertsRemoteWriteURL
+            - Name: remoteWrite_basicAuth_password
+              Value: !Ref AssertsTSDBPassword
+            - Name: httpAuth_password
+              Value: !Ref AssertsTSDBPassword
+          DockerLabels:
+            PROMETHEUS_EXPORTER_PORT: 8014
+            PROMETHEUS_EXPORTER_PATH: /container-stats/actuator/prometheus

--- a/deployment/ecs/otel-collector-iam.yaml
+++ b/deployment/ecs/otel-collector-iam.yaml
@@ -112,51 +112,13 @@ Resources:
                 }
               ]
             }
-        - PolicyName: !Sub "AssertsOTELCollectorRolePolicy-${AssertsEnvironment}"
+        - PolicyName: !Sub "AssertsOTELCollectorECSRolePolicy-${AssertsEnvironment}"
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Resource: "*"
                 Action:
-                  - autoscaling:DescribeAutoScalingGroups
-                  - autoscaling:DescribeTags
-                  - autoscaling:DescribeLoadBalancers
-                  - dynamodb:ListTables
-                  - ec2:DescribeVolumes
-                  - ec2:DescribeInstances
                   - ec2:DescribeSubnets
-                  - ecs:DescribeClusters
-                  - ecs:DescribeServices
-                  - ecs:DescribeTaskDefinition
                   - ecs:DescribeTasks
-                  - ecs:ListAccountSettings
-                  - ecs:ListClusters
-                  - ecs:ListServices
-                  - ecs:ListTaskDefinitionFamilies
-                  - ecs:ListTaskDefinitions
-                  - elasticloadbalancing:DescribeListeners
-                  - elasticloadbalancing:DescribeLoadBalancers
-                  - elasticloadbalancing:DescribeRules
-                  - elasticloadbalancing:DescribeTags
-                  - elasticloadbalancing:DescribeTargetGroups
-                  - elasticloadbalancing:DescribeTargetHealth
-                  - firehose:ListDeliveryStreams
-                  - kinesis:ListStreamConsumers
-                  - kinesis:ListStreams
-                  - kinesis:ListTagsForStream
-                  - kinesisanalytics:ListApplications
-                  - lambda:GetAccountSettings
-                  - lambda:ListEventSourceMappings
-                  - lambda:ListFunctions
-                  - redshift:DescribeClusters
-                  - redshift:ListDatabases
-                  - redshift:ListTables
-                  - s3:ListAllMyBuckets
-                  - sns:ListTopics
-                  - sqs:ListQueues
-                  - tag:GetResources
-                  - elasticmapreduce:ListClusters
-                  - cloudwatch:DescribeAlarms
-                  - cloudwatch:GetMetricData
-                  - cloudwatch:ListMetrics
+                  - ecs:DescribeTaskDefinition

--- a/deployment/ecs/otel-collector-main-aws.yaml
+++ b/deployment/ecs/otel-collector-main-aws.yaml
@@ -1,0 +1,186 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Asserts OTEL Collector Stack
+Parameters:
+  AssertsEnvironment:
+    Type: String
+    Description: The installation environment name
+    Default: Dev
+
+  AssertsSite:
+    Type: String
+    Description: The installation site. For e.g. us-west-2
+    Default: us-west-2
+
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: "Id of VPC in which Asserts OTEL Collector is being installed"
+
+  ALBSubnets:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: "The IDs of the subnets on which the OTEL Collector ALB should be installed."
+
+  ALBIngressSourceCIDR:
+    Type: String
+    Description: "Source IP CIDR for ALB Ingress"
+    Default: 0.0.0.0/0
+
+  Cluster:
+    Type: String
+    Description: "Asserts OTEL Cluster"
+    Default: "asserts-otel"
+
+  ECSSubnets:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: "The IDs of the subnets on which the OTEL Collector ECS Tasks should be installed."
+
+  AssignPublicIPToECSTask:
+    Type: String
+    Description: Determines whether the ECS Task ENIs will be assigned a public IP
+    Default: "ENABLED"
+    AllowedValues: [ "ENABLED", "DISABLED" ]
+
+  AssertsOTELCollectorVersion:
+    Type: String
+    Description: "Asserts OTEL Collector Image version"
+    Default: asserts/otel-collector:v0.0.81-all-exporters
+
+  MetricExporterVersion:
+    Type: String
+    Description: "Metric Exporter Sidecar Image version"
+    Default: docker.io/asserts/ecs-dockerstats-exporter:v1.0.0
+
+  AssertsApiServerURL:
+    Type: String
+    Description: Asserts ApiServer Username
+    Default: https://chief.app.dev.asserts.ai/api-server
+
+  AssertsApiServerUsername:
+    Type: String
+
+  AssertsApiServerPassword:
+    Type: String
+    NoEcho: true
+
+  AssertsRemoteWriteURL:
+    Type: String
+    Default: https://acme.tsdb.asserts.ai/api/v1/write
+
+  AssertsTenantName:
+    Type: String
+    Default: Acme
+
+  AssertsTSDBPassword:
+    Type: String
+    NoEcho: true
+
+  NumCollectorInstances:
+    Type: String
+    Description: Number of Collector Instances to install
+    Default: 1
+
+  LogLevel:
+    Type: String
+    Default: info
+Metadata:
+  "AWS::CloudFormation::Interface":
+    ParameterGroups:
+      - Label: "Common Parameters"
+        Parameters:
+          - AssertsEnvironment
+          - AssertsSite
+          - VpcId
+      - Label: "ALB Parameters"
+        Parameters:
+          - ALBSubnets
+          - ALBIngressSourceCIDR
+      - Label: "ECS Parameters"
+        Parameters:
+          - Cluster
+          - ECSSubnets
+          - AssignPublicIPToECSTask
+          - AssertsOTELCollectorVersion
+          - MetricExporterVersion
+          - AssertsApiServerURL
+          - AssertsApiServerUsername
+          - AssertsApiServerPassword
+          - AssertsTenantName
+          - AssertsRemoteWriteURL
+          - AssertsTSDBPassword
+          - NumCollectorInstances
+Resources:
+  AssertsOTELIAMStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "OTEL Collector"
+      TemplateURL: https://s3.us-west-2.amazonaws.com/downloads.asserts.ai/asserts-otel-collector/ecs/v1/otel-collector-iam.yaml
+      TimeoutInMinutes: 30
+      Parameters:
+        AssertsEnvironment: !Ref AssertsEnvironment
+
+  AssertsOTELSecurityGroupStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "OTEL Collector"
+      TemplateURL: https://s3.us-west-2.amazonaws.com/downloads.asserts.ai/asserts-otel-collector/ecs/v1/otel-collector-security-groups.yaml
+      TimeoutInMinutes: 30
+      Parameters:
+        AssertsEnvironment: !Ref AssertsEnvironment
+        VpcId: !Ref VpcId
+        ALBIngressSourceCIDR: !Ref ALBIngressSourceCIDR
+
+  AssertsOTELALBStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "OTEL Collector"
+      TemplateURL: https://s3.us-west-2.amazonaws.com/downloads.asserts.ai/asserts-otel-collector/ecs/v1/otel-collector-alb.yaml
+      TimeoutInMinutes: 30
+      Parameters:
+        AssertsEnvironment: !Ref AssertsEnvironment
+        VpcId: !Ref VpcId
+        ALBSubnets: !Join [ ",", !Ref ALBSubnets ]
+        ALBSecurityGroupId: !GetAtt AssertsOTELSecurityGroupStack.Outputs.ALBSecurityGroupId
+
+  AssertsOTELECSStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "OTEL Collector"
+      TemplateURL: https://s3.us-west-2.amazonaws.com/downloads.asserts.ai/asserts-otel-collector/ecs/v1/otel-collector-ecs-service-aws.yaml
+      TimeoutInMinutes: 30
+      Parameters:
+        AssertsEnvironment: !Ref AssertsEnvironment
+        AssertsSite: !Ref AssertsSite
+        Cluster: !Ref Cluster
+        ECSSubnets: !Join [ ",", !Ref ALBSubnets ]
+        AssignPublicIPToECSTask: !Ref AssignPublicIPToECSTask
+        AssertsOTELCollectorVersion: !Ref AssertsOTELCollectorVersion
+        MetricExporterVersion: !Ref MetricExporterVersion
+        AssertsApiServerURL: !Ref AssertsApiServerURL
+        AssertsApiServerUsername: !Ref AssertsApiServerUsername
+        AssertsApiServerPassword: !Ref AssertsApiServerPassword
+        AssertsRemoteWriteURL: !Ref AssertsRemoteWriteURL
+        AssertsTenantName: !Ref AssertsTenantName
+        AssertsTSDBPassword: !Ref AssertsTSDBPassword
+        NumCollectorInstances: !Ref NumCollectorInstances
+        ECSSecurityGroupId: !GetAtt AssertsOTELSecurityGroupStack.Outputs.ECSSecurityGroupId
+        CollectorHTTPTargetGroupARN: !GetAtt AssertsOTELALBStack.Outputs.CollectorHTTPTargetGroupARN
+        LogLevel: !Ref LogLevel
+Outputs:
+  OTELCollectorALBDNSName:
+    Description: "The DNS name for the load balancer."
+    Value: !GetAtt AssertsOTELALBStack.Outputs.ALBDNSName

--- a/deployment/ecs/otel-collector-main-cloudtrace.yaml
+++ b/deployment/ecs/otel-collector-main-cloudtrace.yaml
@@ -1,0 +1,191 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Asserts OTEL Collector Stack
+Parameters:
+  AssertsEnvironment:
+    Type: String
+    Description: The installation environment name
+    Default: Dev
+
+  AssertsSite:
+    Type: String
+    Description: The installation site. For e.g. us-west-2
+    Default: us-west-2
+
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: "Id of VPC in which Asserts OTEL Collector is being installed"
+
+  ALBSubnets:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: "The IDs of the subnets on which the OTEL Collector ALB should be installed."
+
+  ALBIngressSourceCIDR:
+    Type: String
+    Description: "Source IP CIDR for ALB Ingress"
+    Default: 0.0.0.0/0
+
+  Cluster:
+    Type: String
+    Description: "Asserts OTEL Cluster"
+    Default: "asserts-otel"
+
+  ECSSubnets:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: "The IDs of the subnets on which the OTEL Collector ECS Tasks should be installed."
+
+  AssignPublicIPToECSTask:
+    Type: String
+    Description: Determines whether the ECS Task ENIs will be assigned a public IP
+    Default: "ENABLED"
+    AllowedValues: [ "ENABLED", "DISABLED" ]
+
+  AssertsOTELCollectorVersion:
+    Type: String
+    Description: "Asserts OTEL Collector Image version"
+    Default: asserts/otel-collector:v0.0.81-all-exporters
+
+  GCPProjectName:
+    Type: String
+    Description: "The GCP Project name"
+
+  MetricExporterVersion:
+    Type: String
+    Description: "Metric Exporter Sidecar Image version"
+    Default: docker.io/asserts/ecs-dockerstats-exporter:v1.0.0
+
+  AssertsApiServerURL:
+    Type: String
+    Description: Asserts ApiServer Username
+    Default: https://chief.app.dev.asserts.ai/api-server
+
+  AssertsApiServerUsername:
+    Type: String
+
+  AssertsApiServerPassword:
+    Type: String
+    NoEcho: true
+
+  AssertsRemoteWriteURL:
+    Type: String
+    Default: https://acme.tsdb.asserts.ai/api/v1/write
+
+  AssertsTenantName:
+    Type: String
+    Default: Acme
+
+  AssertsTSDBPassword:
+    Type: String
+    NoEcho: true
+
+  NumCollectorInstances:
+    Type: String
+    Description: Number of Collector Instances to install
+    Default: 1
+
+  LogLevel:
+    Type: String
+    Default: info
+Metadata:
+  "AWS::CloudFormation::Interface":
+    ParameterGroups:
+      - Label: "Common Parameters"
+        Parameters:
+          - AssertsEnvironment
+          - AssertsSite
+          - VpcId
+      - Label: "ALB Parameters"
+        Parameters:
+          - ALBSubnets
+          - ALBIngressSourceCIDR
+      - Label: "ECS Parameters"
+        Parameters:
+          - Cluster
+          - ECSSubnets
+          - AssignPublicIPToECSTask
+          - AssertsOTELCollectorVersion
+          - MetricExporterVersion
+          - AssertsApiServerURL
+          - AssertsApiServerUsername
+          - AssertsApiServerPassword
+          - AssertsTenantName
+          - AssertsRemoteWriteURL
+          - AssertsTSDBPassword
+          - NumCollectorInstances
+Resources:
+  AssertsOTELIAMStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "OTEL Collector"
+      TemplateURL: https://s3.us-west-2.amazonaws.com/downloads.asserts.ai/asserts-otel-collector/ecs/v1/otel-collector-iam.yaml
+      TimeoutInMinutes: 30
+      Parameters:
+        AssertsEnvironment: !Ref AssertsEnvironment
+
+  AssertsOTELSecurityGroupStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "OTEL Collector"
+      TemplateURL: https://s3.us-west-2.amazonaws.com/downloads.asserts.ai/asserts-otel-collector/ecs/v1/otel-collector-security-groups.yaml
+      TimeoutInMinutes: 30
+      Parameters:
+        AssertsEnvironment: !Ref AssertsEnvironment
+        VpcId: !Ref VpcId
+        ALBIngressSourceCIDR: !Ref ALBIngressSourceCIDR
+
+  AssertsOTELALBStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "OTEL Collector"
+      TemplateURL: https://s3.us-west-2.amazonaws.com/downloads.asserts.ai/asserts-otel-collector/ecs/v1/otel-collector-alb.yaml
+      TimeoutInMinutes: 30
+      Parameters:
+        AssertsEnvironment: !Ref AssertsEnvironment
+        VpcId: !Ref VpcId
+        ALBSubnets: !Join [ ",", !Ref ALBSubnets ]
+        ALBSecurityGroupId: !GetAtt AssertsOTELSecurityGroupStack.Outputs.ALBSecurityGroupId
+
+  AssertsOTELECSStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Tags:
+        - Key: Vendor
+          Value: Asserts
+        - Key: "asserts:component"
+          Value: "OTEL Collector"
+      TemplateURL: https://s3.us-west-2.amazonaws.com/downloads.asserts.ai/asserts-otel-collector/ecs/v1/otel-collector-ecs-service-cloudtrace.yaml
+      TimeoutInMinutes: 30
+      Parameters:
+        AssertsEnvironment: !Ref AssertsEnvironment
+        AssertsSite: !Ref AssertsSite
+        Cluster: !Ref Cluster
+        ECSSubnets: !Join [ ",", !Ref ALBSubnets ]
+        AssignPublicIPToECSTask: !Ref AssignPublicIPToECSTask
+        AssertsOTELCollectorVersion: !Ref AssertsOTELCollectorVersion
+        GCPProjectName: !Ref GCPProjectName
+        MetricExporterVersion: !Ref MetricExporterVersion
+        AssertsApiServerURL: !Ref AssertsApiServerURL
+        AssertsApiServerUsername: !Ref AssertsApiServerUsername
+        AssertsApiServerPassword: !Ref AssertsApiServerPassword
+        AssertsRemoteWriteURL: !Ref AssertsRemoteWriteURL
+        AssertsTenantName: !Ref AssertsTenantName
+        AssertsTSDBPassword: !Ref AssertsTSDBPassword
+        NumCollectorInstances: !Ref NumCollectorInstances
+        ECSSecurityGroupId: !GetAtt AssertsOTELSecurityGroupStack.Outputs.ECSSecurityGroupId
+        CollectorHTTPTargetGroupARN: !GetAtt AssertsOTELALBStack.Outputs.CollectorHTTPTargetGroupARN
+        LogLevel: !Ref LogLevel
+Outputs:
+  OTELCollectorALBDNSName:
+    Description: "The DNS name for the load balancer."
+    Value: !GetAtt AssertsOTELALBStack.Outputs.ALBDNSName

--- a/deployment/ecs/otel-collector-main-otlp.yaml
+++ b/deployment/ecs/otel-collector-main-otlp.yaml
@@ -36,18 +36,23 @@ Parameters:
   AssignPublicIPToECSTask:
     Type: String
     Description: Determines whether the ECS Task ENIs will be assigned a public IP
-    Default: "DISABLED"
+    Default: "ENABLED"
     AllowedValues: [ "ENABLED", "DISABLED" ]
 
   AssertsOTELCollectorVersion:
     Type: String
     Description: "Asserts OTEL Collector Image version"
-    Default: asserts/otel-collector:v0.0.77-ecs
+    Default: asserts/otel-collector:v0.0.81-all-exporters
+
+  MetricExporterVersion:
+    Type: String
+    Description: "Metric Exporter Sidecar Image version"
+    Default: docker.io/asserts/ecs-dockerstats-exporter:v1.0.0
 
   AssertsApiServerURL:
     Type: String
     Description: Asserts ApiServer Username
-    Default: https://chief.dev.app.asserts.ai
+    Default: https://chief.app.dev.asserts.ai/api-server
 
   AssertsApiServerUsername:
     Type: String
@@ -56,14 +61,33 @@ Parameters:
     Type: String
     NoEcho: true
 
+  AssertsRemoteWriteURL:
+    Type: String
+    Default: https://acme.tsdb.asserts.ai
+
+  AssertsTenantName:
+    Type: String
+    Default: Acme
+
+  AssertsTSDBPassword:
+    Type: String
+    NoEcho: true
+
   NumCollectorInstances:
     Type: String
     Description: Number of Collector Instances to install
     Default: 1
 
+  TraceStore:
+    Type: String
+    Description: Backend trace store. One of OTLP, OTLP-HTTP
+    AllowedValues:
+      - OTLP
+      - OTLP-HTTP
+
   OTLPExportEndpoint:
     Type: String
-    Description: OTLP Export Endpoint
+    Description: OTLP Export Endpoint for OTLP over gRPC or HTTP
     Default: jaeger.dev.asserts.ai
 
   LogLevel:
@@ -87,10 +111,14 @@ Metadata:
           - ECSSubnets
           - AssignPublicIPToECSTask
           - AssertsOTELCollectorVersion
+          - MetricExporterVersion
           - AssertsApiServerURL
           - AssertsApiServerUsername
           - AssertsApiServerPassword
           - OTLPExportEndpoint
+          - AssertsTenantName
+          - AssertsRemoteWriteURL
+          - AssertsTSDBPassword
           - NumCollectorInstances
 Resources:
   AssertsOTELIAMStack:
@@ -145,7 +173,7 @@ Resources:
           Value: Asserts
         - Key: "asserts:component"
           Value: "OTEL Collector"
-      TemplateURL: https://s3.us-west-2.amazonaws.com/downloads.asserts.ai/asserts-otel-collector/ecs/v1/otel-collector-ecs-service.yaml
+      TemplateURL: https://s3.us-west-2.amazonaws.com/downloads.asserts.ai/asserts-otel-collector/ecs/v1/otel-collector-ecs-service-otlp.yaml
       TimeoutInMinutes: 30
       Parameters:
         AssertsEnvironment: !Ref AssertsEnvironment
@@ -154,9 +182,14 @@ Resources:
         ECSSubnets: !Join [ ",", !Ref ALBSubnets ]
         AssignPublicIPToECSTask: !Ref AssignPublicIPToECSTask
         AssertsOTELCollectorVersion: !Ref AssertsOTELCollectorVersion
+        TraceStore: !Ref TraceStore
+        MetricExporterVersion: !Ref MetricExporterVersion
         AssertsApiServerURL: !Ref AssertsApiServerURL
         AssertsApiServerUsername: !Ref AssertsApiServerUsername
         AssertsApiServerPassword: !Ref AssertsApiServerPassword
+        AssertsRemoteWriteURL: !Ref AssertsRemoteWriteURL
+        AssertsTenantName: !Ref AssertsTenantName
+        AssertsTSDBPassword: !Ref AssertsTSDBPassword
         NumCollectorInstances: !Ref NumCollectorInstances
         ECSSecurityGroupId: !GetAtt AssertsOTELSecurityGroupStack.Outputs.ECSSecurityGroupId
         CollectorHTTPTargetGroupARN: !GetAtt AssertsOTELALBStack.Outputs.CollectorHTTPTargetGroupARN

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.ecs
-    image: asserts/otel-collector:v0.0.78
+    image: asserts/otel-collector:v0.0.81-all-exporters
     ports:
       - "8888:8888"
       - "8889:8889"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,4 +12,4 @@ services:
       - "4317:4317"
       - "4318:4318"
     env_file:
-      - ecs-test-env.properties
+      - env.properties

--- a/env.properties
+++ b/env.properties
@@ -1,0 +1,23 @@
+TRACE_STORE=AWS-XRAY
+
+# OTLP Endpoint configuration if TRACE_STORE=OTLP or OTLP-HTTP
+# OTLP_ENDPOINT=https://jaeger.dev.asserts.ai:4318
+
+# Asserts Server Configuration
+ASSERTS_SERVER_API_ENDPOINT=https://chief.app.dev.asserts.ai/api-server
+ASSERTS_SERVER_USERNAME=
+ASSERTS_SERVER_PASSWORD=
+ASSERTS_ENV=dev
+ASSERTS_SITE=dev
+
+# Logging Configuration
+LOG_LEVEL=debug
+
+# AWS Credentials
+AWS_ACCESS_KEY_ID=
+AWS_DEFAULT_REGION=
+AWS_REGION=
+AWS_SECRET_ACCESS_KEY=
+AWS_SECURITY_TOKEN=
+AWS_SESSION_EXPIRATION=
+AWS_SESSION_TOKEN=


### PR DESCRIPTION
[ch15496]

The CF template for AWS X-RAY as store backend has been installed in chief and running