### PR TITLE
Update base image from amazonlinux:2 to amazonlinux:2023

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY sample-builder-config.yaml .
 
 RUN ./ocb_0.72.0_linux_amd64 --config=sample-builder-config.yaml
 
-FROM amazonlinux:2
+FROM amazonlinux:2023
 
 WORKDIR /opt/asserts
 COPY --from=build /build/asserts-otel-collector /opt/asserts

--- a/sample-builder-config.yaml
+++ b/sample-builder-config.yaml
@@ -26,6 +26,6 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.72.0
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.72.0
   - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.72.0
-  - gomod: github.com/asserts/asserts-otel-processor/assertsprocessor v0.0.85
+  - gomod: github.com/asserts/asserts-otel-processor/assertsprocessor v0.0.86
 connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.72.0


### PR DESCRIPTION
The latest amazon linux image has glibc 2.34 which asserts-ote-collector requires