### PR TITLE
Configurable otel collector latency histogram buckets

### DIFF
--- a/assertsprocessor/config.go
+++ b/assertsprocessor/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	CustomAttributeConfigs         map[string]map[string][]*CustomAttributeConfig `mapstructure:"custom_attributes" json:"custom_attributes"`
 	CaptureAttributesInMetric      []string                                       `mapstructure:"attributes_as_metric_labels" json:"attributes_as_metric_labels"`
 	DefaultLatencyThreshold        float64                                        `mapstructure:"sampling_latency_threshold_seconds" json:"sampling_latency_threshold_seconds"`
+	LatencyHistogramBuckets        []float64                                      `mapstructure:"latency_histogram_buckets" json:"latency_histogram_buckets"`
 	IgnoreClientErrors             bool                                           `mapstructure:"ignore_client_errors" json:"ignore_client_errors"`
 	LimitPerService                int                                            `mapstructure:"trace_rate_limit_per_service" json:"trace_rate_limit_per_service"`
 	LimitPerRequestPerService      int                                            `mapstructure:"trace_rate_limit_per_service_per_request" json:"trace_rate_limit_per_service_per_request"`

--- a/assertsprocessor/factory.go
+++ b/assertsprocessor/factory.go
@@ -33,6 +33,7 @@ func createDefaultConfig() component.Config {
 		AssertsServer: &map[string]string{
 			"endpoint": "https://chief.app.dev.asserts.ai",
 		},
+		LatencyHistogramBuckets:        []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 90, 120},
 		DefaultLatencyThreshold:        3,
 		LimitPerService:                100,
 		LimitPerRequestPerService:      3,
@@ -69,6 +70,10 @@ func newProcessor(logger *zap.Logger, ctx context.Context, config component.Conf
 		pConfig.CaptureAttributesInMetric = newConfig.CaptureAttributesInMetric
 		pConfig.DefaultLatencyThreshold = newConfig.DefaultLatencyThreshold
 		pConfig.CustomAttributeConfigs = newConfig.CustomAttributeConfigs
+		pConfig.IgnoreClientErrors = newConfig.IgnoreClientErrors
+		if len(newConfig.LatencyHistogramBuckets) > 0 {
+			pConfig.LatencyHistogramBuckets = newConfig.LatencyHistogramBuckets
+		}
 	}
 
 	_spanEnrichmentProcessor, err := buildEnrichmentProcessor(logger, pConfig)

--- a/assertsprocessor/factory_test.go
+++ b/assertsprocessor/factory_test.go
@@ -146,6 +146,8 @@ func TestCreateProcessorMergeFetchedConfig(t *testing.T) {
         "rpc.service"
       ],
       "sampling_latency_threshold_seconds": 0.51,
+	  "latency_histogram_buckets": [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 90.0, 120.0],
+      "ignore_client_errors": true,
       "unknown": "foo"
     }`),
 		expectedErr: nil,
@@ -158,6 +160,8 @@ func TestCreateProcessorMergeFetchedConfig(t *testing.T) {
 	assert.Nil(t, config.CustomAttributeConfigs)
 	assert.Nil(t, config.CaptureAttributesInMetric)
 	assert.Equal(t, 0.5, config.DefaultLatencyThreshold)
+	assert.Nil(t, config.LatencyHistogramBuckets)
+	assert.False(t, config.IgnoreClientErrors)
 
 	var _processorRef, err = factory.CreateTracesProcessor(ctx, createSettings, &config, nextConsumer)
 
@@ -185,4 +189,6 @@ func TestCreateProcessorMergeFetchedConfig(t *testing.T) {
 	assert.Equal(t, "rpc.system", config.CaptureAttributesInMetric[0])
 	assert.Equal(t, "rpc.service", config.CaptureAttributesInMetric[1])
 	assert.Equal(t, 0.51, config.DefaultLatencyThreshold)
+	assert.Equal(t, []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 90, 120}, config.LatencyHistogramBuckets)
+	assert.True(t, config.IgnoreClientErrors)
 }

--- a/assertsprocessor/metric_helper_test.go
+++ b/assertsprocessor/metric_helper_test.go
@@ -183,7 +183,7 @@ func TestCacheEviction(t *testing.T) {
 	assert.Equal(t, 1, cache.Len())
 }
 
-func TestMetricHelperIsUpdated(t *testing.T) {
+func TestMetricHelperIsCaptureAttributesInMetricUpdated(t *testing.T) {
 	currConfig := &Config{
 		CaptureAttributesInMetric: []string{"rpc.system", "rpc.service"},
 	}
@@ -199,13 +199,45 @@ func TestMetricHelperIsUpdated(t *testing.T) {
 	assert.True(t, p.isUpdated(currConfig, newConfig))
 }
 
+func TestMetricHelperIsLatencyHistogramBucketsUpdated(t *testing.T) {
+	currConfig := &Config{
+		LatencyHistogramBuckets: []float64{1, 2.5, 5, 10},
+	}
+	newConfig := &Config{
+		LatencyHistogramBuckets: []float64{1, 2.5, 5, 10, 25},
+	}
+	p := newMetricHelper(
+		logger,
+		currConfig,
+	)
+
+	assert.False(t, p.isUpdated(currConfig, currConfig))
+	assert.True(t, p.isUpdated(currConfig, newConfig))
+}
+
+func TestMetricHelperEmptyLatencyHistogramBuckets(t *testing.T) {
+	currConfig := &Config{
+		LatencyHistogramBuckets: []float64{1, 2.5, 5, 10},
+	}
+	newConfig := &Config{}
+	p := newMetricHelper(
+		logger,
+		currConfig,
+	)
+
+	assert.False(t, p.isUpdated(currConfig, currConfig))
+	assert.False(t, p.isUpdated(currConfig, newConfig))
+}
+
 func TestMetricHelperOnUpdate(t *testing.T) {
 	currConfig := &Config{
 		CaptureAttributesInMetric: []string{"rpc.system", "rpc.service"},
+		LatencyHistogramBuckets:   []float64{1, 2.5, 5, 10},
 		PrometheusExporterPort:    9466,
 	}
 	newConfig := &Config{
 		CaptureAttributesInMetric: []string{"rpc.system", "rpc.service", "rpc.method"},
+		LatencyHistogramBuckets:   []float64{1, 2.5, 5, 10, 25},
 	}
 
 	logger, _ := zap.NewProduction()

--- a/assertsprocessor/metrics.go
+++ b/assertsprocessor/metrics.go
@@ -82,6 +82,7 @@ func (m *metrics) registerLatencyHistogram(captureAttributesInMetric []string) e
 		Namespace: "otel",
 		Subsystem: "span",
 		Name:      "latency_seconds",
+		Buckets:   m.config.LatencyHistogramBuckets,
 	}, spanMetricLabels)
 	err := m.prometheusRegistry.Register(m.latencyHistogram)
 	if err != nil {

--- a/assertsprocessor/metrics_test.go
+++ b/assertsprocessor/metrics_test.go
@@ -10,7 +10,10 @@ import (
 func TestRegisterMetrics(t *testing.T) {
 	logger, _ := zap.NewProduction()
 	reg := &metrics{
-		logger:             logger,
+		logger: logger,
+		config: &Config{
+			LatencyHistogramBuckets: []float64{1, 2.5, 5, 10},
+		},
 		prometheusRegistry: prometheus.NewRegistry(),
 	}
 	attributes := []string{"rpc.system", "rpc.service", "rpc.method",
@@ -27,6 +30,7 @@ func TestUnregisterMetrics(t *testing.T) {
 	logger, _ := zap.NewProduction()
 	reg := &metrics{
 		logger:             logger,
+		config:             &Config{},
 		prometheusRegistry: prometheus.NewRegistry(),
 	}
 	attributes := []string{"rpc.system", "rpc.service", "rpc.method",

--- a/assertsprocessor/span_enrichment.go
+++ b/assertsprocessor/span_enrichment.go
@@ -84,7 +84,7 @@ func (ep *spanEnrichmentProcessorImpl) isUpdated(currConfig *Config, newConfig *
 func (ep *spanEnrichmentProcessorImpl) onUpdate(newConfig *Config) error {
 	newAttributes, err := buildCompiledConfig(ep.logger, newConfig)
 	if err == nil {
-		ep.logger.Info("Updated config RequestContextExps",
+		ep.logger.Info("Updated config CustomAttributeConfigs",
 			zap.Any("New", newConfig.CustomAttributeConfigs),
 		)
 		ep.configRWMutex.Lock()

--- a/sample-builder-config.yaml
+++ b/sample-builder-config.yaml
@@ -26,6 +26,6 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.81.0
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.81.0
   - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.81.0
-  - gomod: github.com/asserts/asserts-otel-processor/assertsprocessor v0.0.88
+  - gomod: github.com/asserts/asserts-otel-processor/assertsprocessor v0.0.89
 connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.81.0

--- a/sample-collector-config.yaml
+++ b/sample-collector-config.yaml
@@ -52,11 +52,11 @@ processors:
           - source_attributes: ["db.operation", "db.name", "net.peer.name", "net.peer.port"]
             regex: "(.+);(.*);(.+);(.*)"
             span_kinds: ["Client"]
-            value_expr: $1#$2#$3#$4
+            value_expr: $$1#$$2#$$3#$$4
           - source_attributes: ["net.peer.name", "net.peer.port"]
             regex: (.+);(.*)
             span_kinds: ["Client"]
-            value_expr: $1#$2
+            value_expr: $$1#$$2
           - source_attributes: ["http.url"]
             span_kinds: ["Client", "Server"]
             regex: "https?://.+?((/[^/?]+){1,2}).*"
@@ -69,7 +69,7 @@ processors:
 service:
   telemetry:
     logs:
-      level: "debug"
+      level: "info"
   pipelines:
     traces:
       receivers: [otlp]


### PR DESCRIPTION
- Increase default max bucket from 10s to 120s